### PR TITLE
0.1.5 dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ build
 dist
 msaf.egg-info
 *.features_msaf_tmp.json
+.idea/*
+.idea/vcs.xml
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ install:
 
 script:
     - python --version
-    - nosetests --with-coverage --cover-package=msaf -v -w tests/
+    - nosetests --with-coverage --cover-package=msaf -vs -w tests/
 
 after_success:
     - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ python:
     - "2.7"
     - "3.4"
     - "3.5"
+    - "3.6"
 
 before_install:
     - bash .travis_dependencies.sh

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -7,6 +7,7 @@ Contributors
 * Stephan Balke <https://github.com/stefan-balke>
 * Keunwoo Choi <https://github.com/keunwoochoi>
 * Rustam S <https://github.com/fortunto2>
+* Cheng-i Wang <https://github.com/wangsix>
 
 OLDA and Laplacian algorithm implementations were forked from the original repos by the titanest Brian McFee:
 <https://github.com/bmcfee/olda> and <https://github.com/bmcfee/laplacian_segmentation>, respectively.

--- a/docs/algorithms.rst
+++ b/docs/algorithms.rst
@@ -18,6 +18,7 @@ Boundary Algorithms
 .. automodule:: msaf.algorithms.olda
 .. automodule:: msaf.algorithms.scluster
 .. automodule:: msaf.algorithms.sf
+.. automodule:: msaf.algorithms.vmo
 
 Label Algorithms
 ----------------
@@ -25,6 +26,7 @@ Label Algorithms
 .. automodule:: msaf.algorithms.fmc2d
 .. automodule:: msaf.algorithms.cnmf
 .. automodule:: msaf.algorithms.scluster
+.. automodule:: msaf.algorithms.vmo
 
 Adding A New Algorithm to MSAF
 ------------------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,8 @@ Changes
 v0.1.5
 ------
 
+* Using KMeans from sklearn instead of scipy for 2D-FMC. Results are better
+* Making sure we are never using more number of clusters than number of segments for 2D-FMC
 * Added new parameter `2dfmc_offset` in the 2D-FMC method
 * Using np.inf normalization for 2D-FMC now, since it seems to yield better results (at least for Beatles TUT)
 * Padding beat-sync features now, seems to fix potential misalignment of boundaries. Some algorithms (2D-FMC, CNMF) seem to yield better results now

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,8 @@ Changes
 v0.1.5
 ------
 
+* Padding beat-sync features now, seems to fix potential misalignment of boundaries. Some algorithms (2D-FMC, CNMF) seem to yield better results now.
+* Modified features file: two new fields may be addeed: `est_beatsync_times` and `ann_beatsync_times`.
 * The member variable `_framesync_times` in the `Features` was never updated. Fixed it
 
 v0.1.4

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,8 @@ Changes
 v0.1.5
 ------
 
-* Padding beat-sync features now, seems to fix potential misalignment of boundaries. Some algorithms (2D-FMC, CNMF) seem to yield better results now.
+* Using np.inf normalization for 2D-FMC now, since it seems to yield better results (at least for Beatles TUT)
+* Padding beat-sync features now, seems to fix potential misalignment of boundaries. Some algorithms (2D-FMC, CNMF) seem to yield better results now
 * Modified features file: two new fields may be addeed: `est_beatsync_times` and `ann_beatsync_times`.
 * The member variable `_framesync_times` in the `Features` was never updated. Fixed it
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changes
 v0.1.5
 ------
 
+* Adapting sonify function to latest numpy.
 * Using KMeans from sklearn instead of scipy for 2D-FMC. Results are better
 * Making sure we are never using more number of clusters than number of segments for 2D-FMC
 * Added new parameter `2dfmc_offset` in the 2D-FMC method

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,11 @@
 Changes
 =======
 
+v0.1.5
+------
+
+* The member variable `_framesync_times` in the `Features` was never updated. Fixed it
+
 v0.1.4
 ------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changes
 v0.1.5
 ------
 
+* Added new parameter `2dfmc_offset` in the 2D-FMC method
 * Using np.inf normalization for 2D-FMC now, since it seems to yield better results (at least for Beatles TUT)
 * Padding beat-sync features now, seems to fix potential misalignment of boundaries. Some algorithms (2D-FMC, CNMF) seem to yield better results now
 * Modified features file: two new fields may be addeed: `est_beatsync_times` and `ann_beatsync_times`.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changes
 v0.1.5
 ------
 
+* Added new `vmo` oracle segmentation method (by Cheng-i Wang, thanks!)
 * Adapting sonify function to latest numpy.
 * Using KMeans from sklearn instead of scipy for 2D-FMC. Results are better
 * Making sure we are never using more number of clusters than number of segments for 2D-FMC

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,8 +4,9 @@ Changes
 v0.1.5
 ------
 
+* Fixed bug tha threw a `TypeError` if multiple algorithms were run in a single JAMS file with `None` and other label_ids in it
 * Added new `vmo` oracle segmentation method (by Cheng-i Wang, thanks!)
-* Adapting sonify function to latest numpy.
+* Adapting sonify function to latest numpy
 * Using KMeans from sklearn instead of scipy for 2D-FMC. Results are better
 * Making sure we are never using more number of clusters than number of segments for 2D-FMC
 * Added new parameter `2dfmc_offset` in the 2D-FMC method

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -53,16 +53,20 @@ The format of the ``json`` file is as follows:
                 "..."
             } 
         }
-        "est_beatsync": [ 0.0, 1.0, "..." ],
-        "ann_beatsync": [ 0.0, 1.0, "..." ]
+        "est_beatsync_times": [ 0.0, 1.0, "..." ],
+        "ann_beatsync_times": [ 0.0, 1.0, "..." ],
+        "est_beats": [ 0.0, 1.0, "..." ],
+        "ann_beats": [ 0.0, 1.0, "..." ]
     }
 
 A brief description for the main keys of this ``json`` file follows:
 
 * ``globals``: contains a set of global parameters used to compute the features.
 * ``metadata``: contains a set of meta-parameters that might become useful for debugging purposes.
-* ``est_beats``: contains the set of estimated beats (using librosa).
-* ``ann_beats``: contains the set of reference beats (only exists if reference beats are available).
+* ``est_beats``: contains the set of estimated beats, in seconds (using librosa).
+* ``ann_beats``: contains the set of reference beats, in seconds (only exists if reference beats are available).
+* ``est_beatsync_times``: contains the set times associated with each (estimated-)beat-synchronous feature (might differ with `est_beats` in the beginning or end).
+* ``ann_beatsync_times``: contains the set times associated with each (annotated-)beat-synchronous feature (might differ with `ann_beats` in the beginning or end).
 * ``<feature_id>`` (e.g., ``pcp``, ``mfcc``): contains the actual features of the given audio file. Inside this key the following sub-keys can be found:
 
     * ``framesync``: Actual frame-wise features.

--- a/examples/run_msaf.py
+++ b/examples/run_msaf.py
@@ -12,7 +12,7 @@ import time
 import msaf
 
 
-def main():
+if __name__ == '__main__':
     """Main function to parse the arguments and call the main process."""
     parser = argparse.ArgumentParser(
         description="Runs the speficied algorithm(s) on the input file or MSAF"
@@ -123,7 +123,3 @@ def main():
 
     # Done!
     logging.info("Done! Took %.2f seconds." % (time.time() - start_time))
-
-
-if __name__ == '__main__':
-    main()

--- a/msaf/algorithms/cnmf/segmenter.py
+++ b/msaf/algorithms/cnmf/segmenter.py
@@ -217,14 +217,14 @@ class Segmenter(SegmenterInterface):
             # The track is too short. We will only output the first and last
             # time stamps
             if self.in_bound_idxs is None:
-                est_idxs = np.array([0, F.shape[0]-1])
+                est_idxs = np.array([0, F.shape[0] - 1])
                 est_labels = [1]
             else:
                 est_idxs = self.in_bound_idxs
                 est_labels = [1] * (len(est_idxs) + 1)
 
         # Make sure that the first and last boundaries are included
-        assert est_idxs[0] == 0  and est_idxs[-1] == F.shape[0] - 1
+        assert est_idxs[0] == 0 and est_idxs[-1] == F.shape[0] - 1
 
         # Post process estimations
         est_idxs, est_labels = self._postprocess(est_idxs, est_labels)

--- a/msaf/algorithms/cnmf/segmenter.py
+++ b/msaf/algorithms/cnmf/segmenter.py
@@ -1,7 +1,5 @@
 # coding: utf-8
-import logging
 import numpy as np
-import pylab as plt
 from scipy.ndimage import filters
 
 import msaf.utils as U
@@ -212,7 +210,8 @@ class Segmenter(SegmenterInterface):
                 self.config["rank_labels"], self.config["R_labels"],
                 niter=niter, bound_idxs=self.in_bound_idxs, in_labels=None)
 
-            est_idxs = np.unique(np.asarray(est_idxs, dtype=int))
+            # Remove empty segments if needed
+            est_idxs, est_labels = U.remove_empty_segments(est_idxs, est_labels)
         else:
             # The track is too short. We will only output the first and last
             # time stamps

--- a/msaf/algorithms/fmc2d/config.py
+++ b/msaf/algorithms/fmc2d/config.py
@@ -4,7 +4,7 @@
 config = {
     "dirichlet": False,
     "xmeans": False,
-    "k": 6,
+    "k": 5,
     "label_norm_feats": "log",  # "min_max", "log", np.inf,
                                 # -np.inf, float >= 0, None
     "label_norm_floor": 0.1,

--- a/msaf/algorithms/fmc2d/config.py
+++ b/msaf/algorithms/fmc2d/config.py
@@ -7,6 +7,7 @@ config = {
     "dirichlet": False,
     "xmeans": False,
     "k": 5,
+    "2dfmc_offset": 4,
     "label_norm_feats": np.inf,  # "min_max", "log", np.inf,
                                  # -np.inf, float >= 0, None
     "label_norm_floor": 0.1,

--- a/msaf/algorithms/fmc2d/config.py
+++ b/msaf/algorithms/fmc2d/config.py
@@ -6,7 +6,7 @@ import numpy as np
 config = {
     "dirichlet": False,
     "xmeans": False,
-    "k": 5,
+    "k": 4,
     "2dfmc_offset": 4,
     "label_norm_feats": np.inf,  # "min_max", "log", np.inf,
                                  # -np.inf, float >= 0, None

--- a/msaf/algorithms/fmc2d/config.py
+++ b/msaf/algorithms/fmc2d/config.py
@@ -1,12 +1,14 @@
 """Config for the 2D-FMC."""
 
+import numpy as np
+
 # 2D-FMC Params
 config = {
     "dirichlet": False,
     "xmeans": False,
     "k": 5,
-    "label_norm_feats": "log",  # "min_max", "log", np.inf,
-                                # -np.inf, float >= 0, None
+    "label_norm_feats": np.inf,  # "min_max", "log", np.inf,
+                                 # -np.inf, float >= 0, None
     "label_norm_floor": 0.1,
     "label_norm_min_db": -80
 }

--- a/msaf/algorithms/fmc2d/config.py
+++ b/msaf/algorithms/fmc2d/config.py
@@ -7,7 +7,7 @@ config = {
     "dirichlet": False,
     "xmeans": False,
     "k": 4,
-    "2dfmc_offset": 4,
+    "2dfmc_offset": 4,  # Number of frames to ignore in the beginning and end of each segment
     "label_norm_feats": np.inf,  # "min_max", "log", np.inf,
                                  # -np.inf, float >= 0, None
     "label_norm_floor": 0.1,

--- a/msaf/algorithms/fmc2d/segmenter.py
+++ b/msaf/algorithms/fmc2d/segmenter.py
@@ -13,8 +13,6 @@ from .xmeans import XMeans
 import msaf.utils as U
 from msaf.algorithms.interface import SegmenterInterface
 
-import matplotlib.pyplot as plt
-
 
 def get_feat_segments(F, bound_idxs):
     """Returns a set of segments defined by the bound_idxs.

--- a/msaf/algorithms/interface.py
+++ b/msaf/algorithms/interface.py
@@ -103,6 +103,13 @@ class SegmenterInterface:
         """Post processes the estimations from the algorithm, removing empty
         segments and making sure the lenghts of the boundaries and labels
         match."""
+        # Make sure we are using the previously input bounds, if any
+        if self.in_bound_idxs is not None:
+            F = self._preprocess()
+            est_labels = U.synchronize_labels(self.in_bound_idxs, est_idxs,
+                                              est_labels, F.shape[0])
+            est_idxs = self.in_bound_idxs
+
         # Remove empty segments if needed
         est_idxs, est_labels = U.remove_empty_segments(est_idxs, est_labels)
 

--- a/msaf/algorithms/vmo/__init__.py
+++ b/msaf/algorithms/vmo/__init__.py
@@ -1,0 +1,2 @@
+from .config import *
+from .segmenter import *

--- a/msaf/algorithms/vmo/__init__.py
+++ b/msaf/algorithms/vmo/__init__.py
@@ -1,2 +1,10 @@
+"""
+Variable Markov Oracle
+----------------------
+.. autosummary::
+    :toctree: generated/
+
+    Segmenter
+"""
 from .config import *
 from .segmenter import *

--- a/msaf/algorithms/vmo/config.py
+++ b/msaf/algorithms/vmo/config.py
@@ -1,4 +1,4 @@
-"""Example of a configuration file for a new algorithm"""
+"""Configuration file for the Variable Markov Oracle method"""
 
 # Algorithm Params
 config = {

--- a/msaf/algorithms/vmo/config.py
+++ b/msaf/algorithms/vmo/config.py
@@ -1,0 +1,11 @@
+"""Example of a configuration file for a new algorithm"""
+
+# Algorithm Params
+config = {
+    "method": 'symbol_spectral',
+    "connectivity": 'sfx'
+}
+
+algo_id = "vmo"  # Identifier of the algorithm
+is_boundary_type = True  # Whether the algorithm extracts boundaries
+is_label_type = True  # Whether the algorithm labels segments

--- a/msaf/algorithms/vmo/segmenter.py
+++ b/msaf/algorithms/vmo/segmenter.py
@@ -1,0 +1,38 @@
+"""
+Example of algorithm for MSAF
+"""
+from msaf.algorithms.interface import SegmenterInterface
+from vmo.analysis.segmentation import segmentation
+# import sklearn.preprocessing as pre
+import vmo
+import librosa
+
+
+class Segmenter(SegmenterInterface):
+    def processFlat(self):
+        """Main process.
+        Returns
+        -------
+        est_idxs : np.array(N)
+            Estimated indeces the segment boundaries in frame indeces.
+        est_labels : np.array(N-1)
+            Estimated labels for the segments.
+        """
+        # Preprocess to obtain features (array(n_frames, n_features))
+
+        F = self._preprocess()
+        F = librosa.util.normalize(F, axis=0)
+        F = librosa.feature.stack_memory(F.T).T
+        # F = pre.normalize(F, axis=0)
+        ideal_t = vmo.find_threshold(F, dim=F.shape[1])
+        oracle = vmo.build_oracle(F, flag='a', threshold=ideal_t[0][1], dim=F.shape[1])
+
+        my_bounds, my_labels = segmentation(oracle,
+                                            method=self.config['method'],
+                                            connectivity=self.config['connectivity'])
+        # Post process estimations
+        est_idxs, est_labels = self._postprocess(my_bounds, my_labels)
+
+        assert est_idxs[0] == 0 and est_idxs[-1] == F.shape[0] - 1
+        # We're done!
+        return est_idxs, est_labels

--- a/msaf/algorithms/vmo/segmenter.py
+++ b/msaf/algorithms/vmo/segmenter.py
@@ -31,7 +31,7 @@ class Segmenter(SegmenterInterface):
                                             method=self.config['method'],
                                             connectivity=self.config['connectivity'])
         # Post process estimations
-        est_idxs, est_labels = self._postprocess(my_bounds, my_labels)
+        est_idxs, est_labels = self._postprocess(my_bounds, my_labels[:-1])
 
         assert est_idxs[0] == 0 and est_idxs[-1] == F.shape[0] - 1
         # We're done!

--- a/msaf/algorithms/vmo/segmenter.py
+++ b/msaf/algorithms/vmo/segmenter.py
@@ -1,5 +1,5 @@
 """
-Example of algorithm for MSAF
+Variable Markov Oracle algorithm
 """
 from msaf.algorithms.interface import SegmenterInterface
 from vmo.analysis.segmentation import segmentation
@@ -9,6 +9,17 @@ import librosa
 
 
 class Segmenter(SegmenterInterface):
+    """
+    This script identifies the structure of a given track using the Variable
+    Markov Oracle technique described here:
+
+    Wang, C., Mysore, J. G., Structural Segmentation With The Variable Markov
+    Oracle And Boundary Adjustment. Proc. of the 41st IEEE International
+    Conference on Acoustics, Speech, and Signal Processing (ICASSP).
+    Shanghai, China, 2016 (`PDF`_).
+
+    .. _PDF: https://ccrma.stanford.edu/~gautham/Site/Publications_files/segmentation-icassp_2016.pdf
+    """
     def processFlat(self):
         """Main process.
         Returns

--- a/msaf/base.py
+++ b/msaf/base.py
@@ -390,6 +390,7 @@ class Features(six.with_metaclass(MetaFeatures)):
         # Make sure we have already computed the features
         self.features
         if self.feat_type is FeatureTypes.framesync:
+            self._compute_framesync_times()
             frame_times = self._framesync_times
         elif self.feat_type is FeatureTypes.est_beatsync:
             frame_times = self._est_beatsync_times

--- a/msaf/base.py
+++ b/msaf/base.py
@@ -477,7 +477,6 @@ class Features(six.with_metaclass(MetaFeatures)):
             raise FeatureTypeNotFound("Type of features not valid.")
 
         # Select features with default parameters
-
         if features_id not in features_registry.keys():
             raise FeaturesNotFound(
                 "The features '%s' are invalid (valid features are %s)"

--- a/msaf/input_output.py
+++ b/msaf/input_output.py
@@ -153,12 +153,11 @@ def align_times(times, frames):
     Returns
     -------
     aligned_times: np.ndarray
-        Aligned times, same size as `times`.
+        Aligned times.
     """
     dist = np.minimum.outer(times, frames)
     bound_frames = np.argmax(np.maximum(0, dist), axis=1)
     aligned_times = np.unique(bound_frames)
-    assert len(aligned_times) == len(times)
     return aligned_times
 
 

--- a/msaf/input_output.py
+++ b/msaf/input_output.py
@@ -141,10 +141,25 @@ def read_references(audio_path, annotator_id=0):
 
 
 def align_times(times, frames):
-    """Aligns the times to the closes frame times (e.g. beats)."""
+    """Aligns the times to the closest frame times (e.g. beats).
+
+    Parameters
+    ----------
+    times: np.ndarray
+        Times in seconds to be aligned.
+    frames: np.ndarray
+        Frame times in seconds.
+
+    Returns
+    -------
+    aligned_times: np.ndarray
+        Aligned times, same size as `times`.
+    """
     dist = np.minimum.outer(times, frames)
     bound_frames = np.argmax(np.maximum(0, dist), axis=1)
-    return np.unique(bound_frames)
+    aligned_times = np.unique(bound_frames)
+    assert len(aligned_times) == len(times)
+    return aligned_times
 
 
 def find_estimation(jam, boundaries_id, labels_id, params):

--- a/msaf/input_output.py
+++ b/msaf/input_output.py
@@ -190,8 +190,8 @@ def find_estimation(jam, boundaries_id, labels_id, params):
     ann = jam.search(namespace=namespace).\
         search(**{"Sandbox.boundaries_id": boundaries_id}).\
         search(**{"Sandbox.labels_id": lambda x:
-                  isinstance(x, six.string_types) and
-                  re.match(labels_id, x) is not None})
+                  (isinstance(x, six.string_types) and
+                  re.match(labels_id, x) is not None) or x is None})
     for key, val in zip(params.keys(), params.values()):
         if isinstance(val, six.string_types):
             ann = ann.search(**{"Sandbox.%s" % key: val})

--- a/msaf/run.py
+++ b/msaf/run.py
@@ -141,7 +141,8 @@ def run_flat(file_struct, bounds_module, labels_module, frame_times, config,
                 # Ground-truth boundaries
                 est_times, est_labels = io.read_references(
                     file_struct.audio_file, annotator_id=annotator_id)
-                est_idxs = io.align_times(est_times, frame_times[:-1])
+                est_idxs = io.align_times(est_times, frame_times)
+                import pdb; pdb.set_trace()
                 if est_idxs[0] != 0:
                     est_idxs = np.concatenate(([0], est_idxs))
                 if est_idxs[-1] != features.shape[0] - 1:
@@ -162,6 +163,7 @@ def run_flat(file_struct, bounds_module, labels_module, frame_times, config,
                                             **config)
                 est_labels = S.processFlat()[1]
 
+    import pdb; pdb.set_trace()
     # Make sure the first and last boundaries are included
     est_times, est_labels = utils.process_segmentation_level(
         est_idxs, est_labels, features.shape[0], frame_times,
@@ -212,6 +214,7 @@ def run_algorithms(file_struct, boundaries_id, labels_id, config,
     # Get the correct frame times
     frame_times = config["features"].frame_times
 
+    import pdb; pdb.set_trace()
     # Segment audio based on type of segmentation
     run_fun = run_hierarchical if config["hier"] else run_flat
     est_times, est_labels = run_fun(file_struct, bounds_module, labels_module,

--- a/msaf/run.py
+++ b/msaf/run.py
@@ -142,12 +142,8 @@ def run_flat(file_struct, bounds_module, labels_module, frame_times, config,
                 est_times, est_labels = io.read_references(
                     file_struct.audio_file, annotator_id=annotator_id)
                 est_idxs = io.align_times(est_times, frame_times)
-                import pdb; pdb.set_trace()
                 if est_idxs[0] != 0:
                     est_idxs = np.concatenate(([0], est_idxs))
-                if est_idxs[-1] != features.shape[0] - 1:
-                    est_idxs = np.concatenate((
-                        est_idxs, [features.shape[0] - 1]))
             except IOError:
                 logging.warning("No references found for file: %s" %
                                 file_struct.audio_file)
@@ -163,7 +159,6 @@ def run_flat(file_struct, bounds_module, labels_module, frame_times, config,
                                             **config)
                 est_labels = S.processFlat()[1]
 
-    import pdb; pdb.set_trace()
     # Make sure the first and last boundaries are included
     est_times, est_labels = utils.process_segmentation_level(
         est_idxs, est_labels, features.shape[0], frame_times,
@@ -214,7 +209,6 @@ def run_algorithms(file_struct, boundaries_id, labels_id, config,
     # Get the correct frame times
     frame_times = config["features"].frame_times
 
-    import pdb; pdb.set_trace()
     # Segment audio based on type of segmentation
     run_fun = run_hierarchical if config["hier"] else run_flat
     est_times, est_labels = run_fun(file_struct, bounds_module, labels_module,

--- a/msaf/run.py
+++ b/msaf/run.py
@@ -138,6 +138,7 @@ def run_flat(file_struct, bounds_module, labels_module, frame_times, config,
             est_idxs, est_labels = S.processFlat()
         else:
             try:
+                # Ground-truth boundaries
                 est_times, est_labels = io.read_references(
                     file_struct.audio_file, annotator_id=annotator_id)
                 est_idxs = io.align_times(est_times, frame_times[:-1])
@@ -369,4 +370,3 @@ def process(in_path, annot_beats=False, feature="pcp", framesync=False,
         return Parallel(n_jobs=n_jobs)(delayed(process_track)(
             file_struct, boundaries_id, labels_id, config,
             annotator_id=annotator_id) for file_struct in file_structs[:])
-

--- a/msaf/utils.py
+++ b/msaf/utils.py
@@ -218,7 +218,7 @@ def process_segmentation_level(est_idxs, est_labels, N, frame_times, dur):
     silence_label = np.max(est_labels) + 1
     est_labels = np.concatenate(([silence_label], est_labels, [silence_label]))
 
-    print(est_times, est_labels)
+    print(est_times, est_labels, dur)
     # Remove empty segments if needed
     est_times, est_labels = remove_empty_segments(est_times, est_labels)
 

--- a/msaf/utils.py
+++ b/msaf/utils.py
@@ -132,8 +132,15 @@ def sonify_clicks(audio, clicks, out_file, fs, offset=0):
     offset: float
         Offset of the clicks with respect to the audio.
     """
-    # Generate clicks
-    audio_clicks = mir_eval.sonify.clicks(clicks + offset, fs)
+    # Generate clicks (this should be done by mir_eval, but its
+    # latest release is not compatible with latest numpy)
+    times = clicks + offset
+    # 1 kHz tone, 100ms
+    click = np.sin(2 * np.pi * np.arange(fs * .1) * 1000 / (1. * fs))
+    # Exponential decay
+    click *= np.exp(-np.arange(fs * .1) / (fs * .01))
+    length = int(times * fs + click.shape[0] + 1)
+    audio_clicks = mir_eval.sonify.clicks(times, fs, length=length)
 
     # Create array to store the audio plus the clicks
     out_audio = np.zeros(max(len(audio), len(audio_clicks)))

--- a/msaf/utils.py
+++ b/msaf/utils.py
@@ -218,6 +218,7 @@ def process_segmentation_level(est_idxs, est_labels, N, frame_times, dur):
     silence_label = np.max(est_labels) + 1
     est_labels = np.concatenate(([silence_label], est_labels, [silence_label]))
 
+    print(est_times, est_labels)
     # Remove empty segments if needed
     est_times, est_labels = remove_empty_segments(est_times, est_labels)
 

--- a/msaf/utils.py
+++ b/msaf/utils.py
@@ -106,6 +106,7 @@ def get_time_frames(dur, anal):
 
 def remove_empty_segments(times, labels):
     """Removes empty segments if needed."""
+    assert len(times) - 1 == len(labels)
     inters = times_to_intervals(times)
     new_inters = []
     new_labels = []
@@ -212,18 +213,17 @@ def process_segmentation_level(est_idxs, est_labels, N, frame_times, dur):
         Estimated labels for each segment.
     """
     assert est_idxs[0] == 0 and est_idxs[-1] == N - 1
+    assert len(est_idxs) - 1 == len(est_labels)
 
     # Add silences, if needed
     est_times = np.concatenate(([0], frame_times[est_idxs], [dur]))
     silence_label = np.max(est_labels) + 1
     est_labels = np.concatenate(([silence_label], est_labels, [silence_label]))
 
-    print(est_times, est_labels, dur)
     # Remove empty segments if needed
     est_times, est_labels = remove_empty_segments(est_times, est_labels)
 
     # Make sure that the first and last times are 0 and duration, respectively
-    print(est_times, est_labels)
     assert np.allclose([est_times[0]], [0]) and \
         np.allclose([est_times[-1]], [dur])
 

--- a/msaf/utils.py
+++ b/msaf/utils.py
@@ -139,7 +139,7 @@ def sonify_clicks(audio, clicks, out_file, fs, offset=0):
     click = np.sin(2 * np.pi * np.arange(fs * .1) * 1000 / (1. * fs))
     # Exponential decay
     click *= np.exp(-np.arange(fs * .1) / (fs * .01))
-    length = int(times * fs + click.shape[0] + 1)
+    length = int(times.max() * fs + click.shape[0] + 1)
     audio_clicks = mir_eval.sonify.clicks(times, fs, length=length)
 
     # Create array to store the audio plus the clicks

--- a/msaf/utils.py
+++ b/msaf/utils.py
@@ -222,6 +222,7 @@ def process_segmentation_level(est_idxs, est_labels, N, frame_times, dur):
     est_times, est_labels = remove_empty_segments(est_times, est_labels)
 
     # Make sure that the first and last times are 0 and duration, respectively
+    print(est_times, est_labels)
     assert np.allclose([est_times[0]], [0]) and \
         np.allclose([est_times[-1]], [dur])
 

--- a/msaf/version.py
+++ b/msaf/version.py
@@ -1,3 +1,3 @@
 """Version info"""
 short_version = '0.1'
-version = '0.1.4'
+version = '0.1.5-dev'

--- a/msaf/version.py
+++ b/msaf/version.py
@@ -1,3 +1,3 @@
 """Version info"""
 short_version = '0.1'
-version = '0.1.5'
+version = '0.1.51'

--- a/msaf/version.py
+++ b/msaf/version.py
@@ -1,3 +1,3 @@
 """Version info"""
 short_version = '0.1'
-version = '0.1.5-dev'
+version = '0.1.5'

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,8 @@ setup(
         'joblib',
         'librosa >= 0.4.2',
         'mir_eval',
-        'pandas'
+        'pandas',
+        'vmo'
     ],
     extras_require={
         'resample': 'scikits.samplerate>=0.3'

--- a/tests/features/chirp_noaudio.json
+++ b/tests/features/chirp_noaudio.json
@@ -14,6 +14,7 @@
     "hop_length": 1024
   }, 
   "est_beats": [], 
+  "est_beatsync_times": [], 
   "cqt": {
     "est_beatsync": [], 
     "params": {

--- a/tests/fixtures/Sargon_test/estimations/Mindless_cut.jams
+++ b/tests/fixtures/Sargon_test/estimations/Mindless_cut.jams
@@ -7,7 +7,7 @@
           "email": ""
         },
         "annotator": {},
-        "version": "0.1.5-dev",
+        "version": "0.1.5",
         "corpus": "",
         "annotation_tools": "",
         "annotation_rules": "",
@@ -61,7 +61,7 @@
       "sandbox": {
         "boundaries_id": "sf",
         "labels_id": null,
-        "timestamp": "2017/03/02 23:20:28",
+        "timestamp": "2017/03/20 19:07:44",
         "annot_beats": false,
         "feature": "pcp",
         "framesync": false,

--- a/tests/fixtures/Sargon_test/estimations/Mindless_cut.jams
+++ b/tests/fixtures/Sargon_test/estimations/Mindless_cut.jams
@@ -1,90 +1,90 @@
 {
-  "sandbox": {}, 
   "annotations": [
     {
-      "namespace": "segment_open", 
-      "sandbox": {
-        "boundaries_id": "sf", 
-        "timestamp": "2016/11/06 15:30:55", 
-        "bound_norm_feats": Infinity, 
-        "k_nearest": 0.04, 
-        "labels_id": null, 
-        "feature": "pcp", 
-        "Mp_adaptive": 28, 
-        "hier": false, 
-        "M_gaussian": 27, 
-        "m_embedded": 3, 
-        "annot_beats": false, 
-        "offset_thres": 0.05, 
-        "framesync": false
-      }, 
-      "time": 0, 
-      "duration": null, 
       "annotation_metadata": {
-        "annotation_tools": "", 
         "curator": {
-          "name": "", 
+          "name": "",
           "email": ""
-        }, 
-        "annotator": {}, 
-        "version": "0.1.5-dev", 
-        "corpus": "", 
-        "annotation_rules": "", 
-        "validation": "", 
+        },
+        "annotator": {},
+        "version": "0.1.5-dev",
+        "corpus": "",
+        "annotation_tools": "",
+        "annotation_rules": "",
+        "validation": "",
         "data_source": "MSAF"
-      }, 
+      },
       "data": [
         {
-          "duration": 0.417959, 
-          "confidence": null, 
-          "value": "A", 
-          "time": 0.0
-        }, 
+          "time": 0.0,
+          "duration": 0.417959,
+          "value": "A",
+          "confidence": null
+        },
         {
-          "duration": 8.312744, 
-          "confidence": null, 
-          "value": "@", 
-          "time": 0.417959
-        }, 
+          "time": 0.417959,
+          "duration": 8.312744,
+          "value": "@",
+          "confidence": null
+        },
         {
-          "duration": 24.845351, 
-          "confidence": null, 
-          "value": "@", 
-          "time": 8.730703
-        }, 
+          "time": 8.730703,
+          "duration": 24.845351,
+          "value": "@",
+          "confidence": null
+        },
         {
-          "duration": 11.609977, 
-          "confidence": null, 
-          "value": "@", 
-          "time": 33.576054
-        }, 
+          "time": 33.576054,
+          "duration": 11.609977,
+          "value": "@",
+          "confidence": null
+        },
         {
-          "duration": 11.052698000000001, 
-          "confidence": null, 
-          "value": "@", 
-          "time": 45.186032000000004
-        }, 
+          "time": 45.186032000000004,
+          "duration": 11.052698000000001,
+          "value": "@",
+          "confidence": null
+        },
         {
-          "duration": 7.151746, 
-          "confidence": null, 
-          "value": "@", 
-          "time": 56.238730000000004
-        }, 
+          "time": 56.238730000000004,
+          "duration": 7.151746,
+          "value": "@",
+          "confidence": null
+        },
         {
-          "duration": 0.011519000000000001, 
-          "confidence": null, 
-          "value": "A", 
-          "time": 63.39047600000001
+          "time": 63.39047600000001,
+          "duration": 0.011519000000000001,
+          "value": "A",
+          "confidence": null
         }
-      ]
+      ],
+      "sandbox": {
+        "boundaries_id": "sf",
+        "labels_id": null,
+        "timestamp": "2017/03/02 21:20:35",
+        "annot_beats": false,
+        "feature": "pcp",
+        "framesync": false,
+        "M_gaussian": 27,
+        "m_embedded": 3,
+        "k_nearest": 0.04,
+        "Mp_adaptive": 28,
+        "offset_thres": 0.05,
+        "bound_norm_feats": Infinity,
+        "hier": false
+      },
+      "namespace": "segment_open",
+      "time": 0,
+      "duration": null
     }
-  ], 
+  ],
   "file_metadata": {
-    "jams_version": "0.2.1", 
-    "title": "", 
-    "identifiers": {}, 
-    "release": "", 
-    "duration": 63.45142857142857, 
-    "artist": ""
-  }
+    "title": "",
+    "artist": "",
+    "release": "",
+    "duration": 63.45142857142857,
+    "identifiers": {},
+    "jams_version": "0.2.1"
+  },
+  "sandbox": {}
 }

--- a/tests/fixtures/Sargon_test/estimations/Mindless_cut.jams
+++ b/tests/fixtures/Sargon_test/estimations/Mindless_cut.jams
@@ -61,7 +61,7 @@
       "sandbox": {
         "boundaries_id": "sf",
         "labels_id": null,
-        "timestamp": "2017/03/02 21:32:17",
+        "timestamp": "2017/03/02 21:41:34",
         "annot_beats": false,
         "feature": "pcp",
         "framesync": false,

--- a/tests/fixtures/Sargon_test/estimations/Mindless_cut.jams
+++ b/tests/fixtures/Sargon_test/estimations/Mindless_cut.jams
@@ -61,7 +61,7 @@
       "sandbox": {
         "boundaries_id": "sf",
         "labels_id": null,
-        "timestamp": "2017/03/02 21:41:34",
+        "timestamp": "2017/03/02 23:20:28",
         "annot_beats": false,
         "feature": "pcp",
         "framesync": false,

--- a/tests/fixtures/Sargon_test/estimations/Mindless_cut.jams
+++ b/tests/fixtures/Sargon_test/estimations/Mindless_cut.jams
@@ -5,7 +5,7 @@
       "namespace": "segment_open", 
       "sandbox": {
         "boundaries_id": "sf", 
-        "timestamp": "2016/11/06 13:53:37", 
+        "timestamp": "2016/11/06 15:30:55", 
         "bound_norm_feats": Infinity, 
         "k_nearest": 0.04, 
         "labels_id": null, 
@@ -35,46 +35,46 @@
       }, 
       "data": [
         {
-          "duration": 0.04644, 
+          "duration": 0.417959, 
           "confidence": null, 
           "value": "A", 
           "time": 0.0
         }, 
         {
-          "duration": 8.730703, 
+          "duration": 8.312744, 
           "confidence": null, 
           "value": "@", 
-          "time": 0.04644
+          "time": 0.417959
         }, 
         {
-          "duration": 24.055873000000002, 
+          "duration": 24.845351, 
           "confidence": null, 
           "value": "@", 
-          "time": 8.777143
+          "time": 8.730703
         }, 
         {
-          "duration": 11.981497000000001, 
+          "duration": 11.609977, 
           "confidence": null, 
           "value": "@", 
-          "time": 32.833016
+          "time": 33.576054
         }, 
         {
           "duration": 11.052698000000001, 
           "confidence": null, 
           "value": "@", 
-          "time": 44.814512
+          "time": 45.186032000000004
         }, 
         {
-          "duration": 6.315828000000001, 
+          "duration": 7.151746, 
           "confidence": null, 
           "value": "@", 
-          "time": 55.867211000000005
+          "time": 56.238730000000004
         }, 
         {
-          "duration": 1.2683900000000001, 
+          "duration": 0.011519000000000001, 
           "confidence": null, 
           "value": "A", 
-          "time": 62.183039
+          "time": 63.39047600000001
         }
       ]
     }

--- a/tests/fixtures/Sargon_test/estimations/Mindless_cut.jams
+++ b/tests/fixtures/Sargon_test/estimations/Mindless_cut.jams
@@ -5,11 +5,11 @@
       "namespace": "segment_open", 
       "sandbox": {
         "boundaries_id": "sf", 
-        "timestamp": "2016/10/10 22:34:03", 
+        "timestamp": "2016/11/06 13:53:37", 
         "bound_norm_feats": Infinity, 
-        "feature": "pcp", 
-        "labels_id": null, 
         "k_nearest": 0.04, 
+        "labels_id": null, 
+        "feature": "pcp", 
         "Mp_adaptive": 28, 
         "hier": false, 
         "M_gaussian": 27, 
@@ -27,7 +27,7 @@
           "email": ""
         }, 
         "annotator": {}, 
-        "version": "0.1.3-dev", 
+        "version": "0.1.5-dev", 
         "corpus": "", 
         "annotation_rules": "", 
         "validation": "", 

--- a/tests/fixtures/Sargon_test/estimations/Mindless_cut.jams
+++ b/tests/fixtures/Sargon_test/estimations/Mindless_cut.jams
@@ -61,7 +61,7 @@
       "sandbox": {
         "boundaries_id": "sf",
         "labels_id": null,
-        "timestamp": "2017/03/02 21:20:35",
+        "timestamp": "2017/03/02 21:32:17",
         "annot_beats": false,
         "feature": "pcp",
         "framesync": false,

--- a/tests/fixtures/Sargon_test/estimations/Mindless_cut2.jams
+++ b/tests/fixtures/Sargon_test/estimations/Mindless_cut2.jams
@@ -7,7 +7,7 @@
           "email": ""
         },
         "annotator": {},
-        "version": "0.1.5-dev",
+        "version": "0.1.5",
         "corpus": "",
         "annotation_tools": "",
         "annotation_rules": "",
@@ -61,7 +61,7 @@
       "sandbox": {
         "boundaries_id": "sf",
         "labels_id": null,
-        "timestamp": "2017/03/02 23:20:28",
+        "timestamp": "2017/03/20 19:07:44",
         "annot_beats": false,
         "feature": "pcp",
         "framesync": false,

--- a/tests/fixtures/Sargon_test/estimations/Mindless_cut2.jams
+++ b/tests/fixtures/Sargon_test/estimations/Mindless_cut2.jams
@@ -1,90 +1,90 @@
 {
-  "sandbox": {}, 
   "annotations": [
     {
-      "namespace": "segment_open", 
-      "sandbox": {
-        "boundaries_id": "sf", 
-        "timestamp": "2016/11/06 15:30:55", 
-        "bound_norm_feats": Infinity, 
-        "k_nearest": 0.04, 
-        "labels_id": null, 
-        "feature": "pcp", 
-        "Mp_adaptive": 28, 
-        "hier": false, 
-        "M_gaussian": 27, 
-        "m_embedded": 3, 
-        "annot_beats": false, 
-        "offset_thres": 0.05, 
-        "framesync": false
-      }, 
-      "time": 0, 
-      "duration": null, 
       "annotation_metadata": {
-        "annotation_tools": "", 
         "curator": {
-          "name": "", 
+          "name": "",
           "email": ""
-        }, 
-        "annotator": {}, 
-        "version": "0.1.5-dev", 
-        "corpus": "", 
-        "annotation_rules": "", 
-        "validation": "", 
+        },
+        "annotator": {},
+        "version": "0.1.5-dev",
+        "corpus": "",
+        "annotation_tools": "",
+        "annotation_rules": "",
+        "validation": "",
         "data_source": "MSAF"
-      }, 
+      },
       "data": [
         {
-          "duration": 0.417959, 
-          "confidence": null, 
-          "value": "A", 
-          "time": 0.0
-        }, 
+          "time": 0.0,
+          "duration": 0.417959,
+          "value": "A",
+          "confidence": null
+        },
         {
-          "duration": 8.312744, 
-          "confidence": null, 
-          "value": "@", 
-          "time": 0.417959
-        }, 
+          "time": 0.417959,
+          "duration": 8.312744,
+          "value": "@",
+          "confidence": null
+        },
         {
-          "duration": 24.845351, 
-          "confidence": null, 
-          "value": "@", 
-          "time": 8.730703
-        }, 
+          "time": 8.730703,
+          "duration": 24.845351,
+          "value": "@",
+          "confidence": null
+        },
         {
-          "duration": 11.609977, 
-          "confidence": null, 
-          "value": "@", 
-          "time": 33.576054
-        }, 
+          "time": 33.576054,
+          "duration": 11.609977,
+          "value": "@",
+          "confidence": null
+        },
         {
-          "duration": 11.052698000000001, 
-          "confidence": null, 
-          "value": "@", 
-          "time": 45.186032000000004
-        }, 
+          "time": 45.186032000000004,
+          "duration": 11.052698000000001,
+          "value": "@",
+          "confidence": null
+        },
         {
-          "duration": 7.151746, 
-          "confidence": null, 
-          "value": "@", 
-          "time": 56.238730000000004
-        }, 
+          "time": 56.238730000000004,
+          "duration": 7.151746,
+          "value": "@",
+          "confidence": null
+        },
         {
-          "duration": 0.011519000000000001, 
-          "confidence": null, 
-          "value": "A", 
-          "time": 63.39047600000001
+          "time": 63.39047600000001,
+          "duration": 0.011519000000000001,
+          "value": "A",
+          "confidence": null
         }
-      ]
+      ],
+      "sandbox": {
+        "boundaries_id": "sf",
+        "labels_id": null,
+        "timestamp": "2017/03/02 21:20:35",
+        "annot_beats": false,
+        "feature": "pcp",
+        "framesync": false,
+        "M_gaussian": 27,
+        "m_embedded": 3,
+        "k_nearest": 0.04,
+        "Mp_adaptive": 28,
+        "offset_thres": 0.05,
+        "bound_norm_feats": Infinity,
+        "hier": false
+      },
+      "namespace": "segment_open",
+      "time": 0,
+      "duration": null
     }
-  ], 
+  ],
   "file_metadata": {
-    "jams_version": "0.2.1", 
-    "title": "", 
-    "identifiers": {}, 
-    "release": "", 
-    "duration": 63.45142857142857, 
-    "artist": ""
-  }
+    "title": "",
+    "artist": "",
+    "release": "",
+    "duration": 63.45142857142857,
+    "identifiers": {},
+    "jams_version": "0.2.1"
+  },
+  "sandbox": {}
 }

--- a/tests/fixtures/Sargon_test/estimations/Mindless_cut2.jams
+++ b/tests/fixtures/Sargon_test/estimations/Mindless_cut2.jams
@@ -61,7 +61,7 @@
       "sandbox": {
         "boundaries_id": "sf",
         "labels_id": null,
-        "timestamp": "2017/03/02 21:32:17",
+        "timestamp": "2017/03/02 21:41:34",
         "annot_beats": false,
         "feature": "pcp",
         "framesync": false,

--- a/tests/fixtures/Sargon_test/estimations/Mindless_cut2.jams
+++ b/tests/fixtures/Sargon_test/estimations/Mindless_cut2.jams
@@ -61,7 +61,7 @@
       "sandbox": {
         "boundaries_id": "sf",
         "labels_id": null,
-        "timestamp": "2017/03/02 21:41:34",
+        "timestamp": "2017/03/02 23:20:28",
         "annot_beats": false,
         "feature": "pcp",
         "framesync": false,

--- a/tests/fixtures/Sargon_test/estimations/Mindless_cut2.jams
+++ b/tests/fixtures/Sargon_test/estimations/Mindless_cut2.jams
@@ -5,7 +5,7 @@
       "namespace": "segment_open", 
       "sandbox": {
         "boundaries_id": "sf", 
-        "timestamp": "2016/11/06 13:53:37", 
+        "timestamp": "2016/11/06 15:30:55", 
         "bound_norm_feats": Infinity, 
         "k_nearest": 0.04, 
         "labels_id": null, 
@@ -35,46 +35,46 @@
       }, 
       "data": [
         {
-          "duration": 0.04644, 
+          "duration": 0.417959, 
           "confidence": null, 
           "value": "A", 
           "time": 0.0
         }, 
         {
-          "duration": 8.730703, 
+          "duration": 8.312744, 
           "confidence": null, 
           "value": "@", 
-          "time": 0.04644
+          "time": 0.417959
         }, 
         {
-          "duration": 24.055873000000002, 
+          "duration": 24.845351, 
           "confidence": null, 
           "value": "@", 
-          "time": 8.777143
+          "time": 8.730703
         }, 
         {
-          "duration": 11.981497000000001, 
+          "duration": 11.609977, 
           "confidence": null, 
           "value": "@", 
-          "time": 32.833016
+          "time": 33.576054
         }, 
         {
           "duration": 11.052698000000001, 
           "confidence": null, 
           "value": "@", 
-          "time": 44.814512
+          "time": 45.186032000000004
         }, 
         {
-          "duration": 6.315828000000001, 
+          "duration": 7.151746, 
           "confidence": null, 
           "value": "@", 
-          "time": 55.867211000000005
+          "time": 56.238730000000004
         }, 
         {
-          "duration": 1.2683900000000001, 
+          "duration": 0.011519000000000001, 
           "confidence": null, 
           "value": "A", 
-          "time": 62.183039
+          "time": 63.39047600000001
         }
       ]
     }

--- a/tests/fixtures/Sargon_test/estimations/Mindless_cut2.jams
+++ b/tests/fixtures/Sargon_test/estimations/Mindless_cut2.jams
@@ -5,11 +5,11 @@
       "namespace": "segment_open", 
       "sandbox": {
         "boundaries_id": "sf", 
-        "timestamp": "2016/10/10 22:34:03", 
+        "timestamp": "2016/11/06 13:53:37", 
         "bound_norm_feats": Infinity, 
-        "feature": "pcp", 
-        "labels_id": null, 
         "k_nearest": 0.04, 
+        "labels_id": null, 
+        "feature": "pcp", 
         "Mp_adaptive": 28, 
         "hier": false, 
         "M_gaussian": 27, 
@@ -27,7 +27,7 @@
           "email": ""
         }, 
         "annotator": {}, 
-        "version": "0.1.3-dev", 
+        "version": "0.1.5-dev", 
         "corpus": "", 
         "annotation_rules": "", 
         "validation": "", 

--- a/tests/fixtures/Sargon_test/estimations/Mindless_cut2.jams
+++ b/tests/fixtures/Sargon_test/estimations/Mindless_cut2.jams
@@ -61,7 +61,7 @@
       "sandbox": {
         "boundaries_id": "sf",
         "labels_id": null,
-        "timestamp": "2017/03/02 21:20:35",
+        "timestamp": "2017/03/02 21:32:17",
         "annot_beats": false,
         "feature": "pcp",
         "framesync": false,

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -174,6 +174,8 @@ def test_no_audio():
     they have been previously been computed."""
     # This file doesn't exist
     no_audio_file_struct = FileStruct("fixtures/chirp_noaudio.mp3")
+    no_audio_file_struct.features_file = "features/chirp_noaudio.json"
+    import pdb; pdb.set_trace()
     feat_type = FeatureTypes.framesync
     CQT(no_audio_file_struct, feat_type, sr=22050).features
     assert (os.path.isfile(no_audio_file_struct.features_file))
@@ -188,6 +190,7 @@ def test_no_audio_no_params():
     want to be explored and no audio file is found."""
     # This file doesn't exist
     no_audio_file_struct = FileStruct("fixtures/chirp_noaudio.mp3")
+    no_audio_file_struct.features_file = "features/chirp_noaudio.json"
     feat_type = FeatureTypes.framesync
     CQT(no_audio_file_struct, feat_type, sr=11025).features
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -175,7 +175,6 @@ def test_no_audio():
     # This file doesn't exist
     no_audio_file_struct = FileStruct("fixtures/chirp_noaudio.mp3")
     no_audio_file_struct.features_file = "features/chirp_noaudio.json"
-    import pdb; pdb.set_trace()
     feat_type = FeatureTypes.framesync
     CQT(no_audio_file_struct, feat_type, sr=22050).features
     assert (os.path.isfile(no_audio_file_struct.features_file))

--- a/tests/test_fmc2d.py
+++ b/tests/test_fmc2d.py
@@ -1,0 +1,35 @@
+from enum import Enum
+from nose.tools import raises
+import numpy as np
+import os
+
+# Msaf imports
+from msaf.algorithms import fmc2d
+
+
+def test_get_feat_segments():
+    F = np.random.random((100, 10))
+    bound_idxs = np.array([0, 10, 40, 70])
+    feat_segments = fmc2d.get_feat_segments(F, bound_idxs)
+    assert len(feat_segments) == len(bound_idxs) - 1
+
+
+@raises(AssertionError)
+def test_get_feat_segments_outbounds_down():
+    F = np.random.random((100, 10))
+    bound_idxs = np.array([-10, 10, 40, 70])
+    fmc2d.get_feat_segments(F, bound_idxs)
+
+
+@raises(AssertionError)
+def test_get_feat_segments_outbounds_up():
+    F = np.random.random((100, 10))
+    bound_idxs = np.array([0, 10, 40, 70, 120])
+    fmc2d.get_feat_segments(F, bound_idxs)
+
+
+@raises(AssertionError)
+def test_get_feat_segments_empty():
+    F = np.random.random((100, 10))
+    bound_idxs = np.array([])
+    fmc2d.get_feat_segments(F, bound_idxs)

--- a/tests/test_input_output.py
+++ b/tests/test_input_output.py
@@ -158,3 +158,10 @@ def test_write_mirex():
 
     # Cleanup
     os.remove(out_file)
+
+
+def test_align_times():
+    times = np.array([0, 10, 20, 30])
+    frames = np.array([0, 12, 19, 25, 31])
+    aligned_times = msaf.io.align_times(times, frames)
+    assert len(times) == len(aligned_times)

--- a/tests/test_input_output.py
+++ b/tests/test_input_output.py
@@ -13,7 +13,6 @@ import shutil
 
 # Msaf imports
 import msaf
-from msaf.exceptions import WrongAlgorithmID
 from msaf.input_output import FileStruct
 
 # Global vars
@@ -51,14 +50,6 @@ def test_find_estimation():
     params = {"hier": False}
     ann = msaf.io.find_estimation(jam, "sf", None, params)
     assert len(ann.data) == 21
-
-
-@raises(WrongAlgorithmID)
-def test_find_estimation_wrong():
-    est_file = os.path.join("fixtures", "01-Sargon-Mindless-ests.jams")
-    jam = jams.load(est_file)
-    params = {"hier": False}
-    msaf.io.find_estimation(jam, "sf", "caca", params)
 
 
 def test_find_estimation_multiple():

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -87,6 +87,9 @@ def test_run_algorithms():
     # Add None to labels
     label_ids += [None]
 
+    bound_ids = ["cnmf", "scluster"]
+    label_ids = ["vmo"]
+
     # Config params
     feature = "pcp"
     annot_beats = False
@@ -136,11 +139,6 @@ def test_run_algorithms():
                                 decimal=2)
 
     # Running all boundary algorithms on a relatively long file
-    for bound_id in bound_ids:
-        if bound_id == "gt":
-            continue
-        yield (_test_run_msaf, bound_id, None, False)
-
     # Combining boundaries with labels
     for bound_id in bound_ids:
         if bound_id == "gt" or bound_id == "example":
@@ -148,13 +146,14 @@ def test_run_algorithms():
         for label_id in label_ids:
             yield (_test_run_msaf, bound_id, label_id, False)
 
+    # TODO
     # Test the hierarchical algorithms
-    hier_ids = ["olda", "scluster"]
-    for hier_bounds_id in hier_ids:
-        for hier_labels_id in hier_ids:
-            if hier_labels_id == "olda":
-                hier_labels_id = "fmc2d"
-            yield (_test_run_msaf, hier_bounds_id, hier_labels_id, True)
+    # hier_ids = ["olda", "scluster"]
+    # for hier_bounds_id in hier_ids:
+        # for hier_labels_id in hier_ids:
+            # if hier_labels_id == "olda":
+                # hier_labels_id = "fmc2d"
+            # yield (_test_run_msaf, hier_bounds_id, hier_labels_id, True)
 
 
 @raises(NoHierBoundaryError)

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -87,11 +87,6 @@ def test_run_algorithms():
     # Add None to labels
     label_ids += [None]
 
-    # bound_ids = ["cnmf", "scluster"]
-    # label_ids = ["vmo"]
-    bound_ids = ["olda"]
-    label_ids = ["cnmf"]
-
     # Config params
     feature = "pcp"
     annot_beats = False

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -235,9 +235,9 @@ def test_process_sonify():
 
 
 # TODO: Travis
-@image_comparison(baseline_images=['run_bounds'], extensions=['png'])
-def test_process_plot():
-    est_times, est_labels = msaf.run.process(long_audio_file, plot=True)
+# @image_comparison(baseline_images=['run_bounds'], extensions=['png'])
+# def test_process_plot():
+    # est_times, est_labels = msaf.run.process(long_audio_file, plot=True)
 
 
 def test_process_dataset():

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -82,7 +82,7 @@ def test_run_algorithms():
     label_ids = msaf.io.get_all_label_algorithms()
 
     # Add ground truth to boundary id
-    bound_ids += ["gt", "example"]
+    bound_ids += ["gt"]
 
     # Add None to labels
     label_ids += [None]
@@ -138,7 +138,7 @@ def test_run_algorithms():
     # Running all boundary algorithms on a relatively long file
     # Combining boundaries with labels
     for bound_id in bound_ids:
-        if bound_id == "gt" or bound_id == "example":
+        if bound_id == "gt":
             continue
         for label_id in label_ids:
             yield (_test_run_msaf, bound_id, label_id, False)

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -5,6 +5,7 @@
 # nosetests
 
 # For plotting and testing
+from __future__ import print_function
 import matplotlib
 matplotlib.use('Agg')
 matplotlib.rcParams.update(matplotlib.rcParamsDefault)
@@ -96,6 +97,7 @@ def test_run_algorithms():
     # Running all algorithms on a file that is too short
     for bound_id in bound_ids:
         for label_id in label_ids:
+            print("bound_id: %s,\tlabel_id: %s" % (bound_id, label_id))
             config = msaf.io.get_configuration(feature, annot_beats, framesync,
                                                bound_id, label_id)
             config["hier"] = False
@@ -114,6 +116,7 @@ def test_run_algorithms():
     file_struct.features_file = msaf.config.features_tmp_file
 
     def _test_run_msaf(bound_id, label_id, hier=False):
+        print("bound_id: %s,\tlabel_id: %s" % (bound_id, label_id))
         config = msaf.io.get_configuration(feature, annot_beats, framesync,
                                            bound_id, label_id)
         config["hier"] = hier

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -82,7 +82,7 @@ def test_run_algorithms():
     label_ids = msaf.io.get_all_label_algorithms()
 
     # Add ground truth to boundary id
-    bound_ids += ["gt"]
+    bound_ids += ["gt", "example"]
 
     # Add None to labels
     label_ids += [None]

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -143,14 +143,13 @@ def test_run_algorithms():
         for label_id in label_ids:
             yield (_test_run_msaf, bound_id, label_id, False)
 
-    # TODO
     # Test the hierarchical algorithms
-    # hier_ids = ["olda", "scluster"]
-    # for hier_bounds_id in hier_ids:
-        # for hier_labels_id in hier_ids:
-            # if hier_labels_id == "olda":
-                # hier_labels_id = "fmc2d"
-            # yield (_test_run_msaf, hier_bounds_id, hier_labels_id, True)
+    hier_ids = ["olda", "scluster"]
+    for hier_bounds_id in hier_ids:
+        for hier_labels_id in hier_ids:
+            if hier_labels_id == "olda":
+                hier_labels_id = "fmc2d"
+            yield (_test_run_msaf, hier_bounds_id, hier_labels_id, True)
 
 
 @raises(NoHierBoundaryError)
@@ -176,9 +175,6 @@ def test_no_gt_flat_bounds():
 
 
 def test_process_track():
-    feature = "pcp"
-    annot_beats = False
-    framesync = False
     bounds_id = "foote"
     labels_id = None
     file_struct = msaf.io.FileStruct(audio_file)

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -87,8 +87,10 @@ def test_run_algorithms():
     # Add None to labels
     label_ids += [None]
 
-    bound_ids = ["cnmf", "scluster"]
-    label_ids = ["vmo"]
+    # bound_ids = ["cnmf", "scluster"]
+    # label_ids = ["vmo"]
+    bound_ids = ["olda"]
+    label_ids = ["cnmf"]
 
     # Config params
     feature = "pcp"


### PR DESCRIPTION
* Fixed bug tha threw a `TypeError` if multiple algorithms were run in a single JAMS file with `None` and other label_ids in it
* Added new `vmo` oracle segmentation method (by Cheng-i Wang, thanks!)
* Adapting sonify function to latest numpy
* Using KMeans from sklearn instead of scipy for 2D-FMC. Results are better
* Making sure we are never using more number of clusters than number of segments for 2D-FMC
* Added new parameter `2dfmc_offset` in the 2D-FMC method
* Using np.inf normalization for 2D-FMC now, since it seems to yield better results (at least for Beatles TUT)
* Padding beat-sync features now, seems to fix potential misalignment of boundaries. Some algorithms (2D-FMC, CNMF) seem to yield better results now
* Modified features file: two new fields may be addeed: `est_beatsync_times` and `ann_beatsync_times`.
* The member variable `_framesync_times` in the `Features` was never updated. Fixed it
