### PR TITLE
Example for annotated beats. 

### DIFF
--- a/examples/Run MSAF.ipynb
+++ b/examples/Run MSAF.ipynb
@@ -212,8 +212,8 @@
    "source": [
     "sr = 44100\n",
     "hop_length = 1024\n",
-    "audio_file = \"../datasets/Sargon/audio/02-Sargon-Shattered World.mp3\"\n",
-    "audio = librosa.load(audio_file, sr=sr)[0]\n",
+    "beats_audio_file = \"../datasets/Sargon/audio/02-Sargon-Shattered World.mp3\"\n",
+    "audio = librosa.load(beats_audio_file, sr=sr)[0]\n",
     "audio_harmonic, audio_percussive = librosa.effects.hpss(audio)\n",
     "\n",
     "# Compute beats\n",

--- a/examples/Run MSAF.ipynb
+++ b/examples/Run MSAF.ipynb
@@ -199,6 +199,75 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Using Annotated Beats ###\n",
+    "\n",
+    "MSAF can calculate the beats or use annotated ones. The annotations should be store in a jams file, for this notebook we used a [simple jams example](http://pythonhosted.org/jams/examples.html). "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sr = 44100\n",
+    "hop_length = 1024\n",
+    "audio_file = \"../datasets/Sargon/audio/02-Sargon-Shattered World.mp3\"\n",
+    "audio = librosa.load(audio_file, sr=sr)[0]\n",
+    "audio_harmonic, audio_percussive = librosa.effects.hpss(audio)\n",
+    "\n",
+    "# Compute beats\n",
+    "tempo, frames = librosa.beat.beat_track(y=audio_percussive, \n",
+    "                                        sr=sr, hop_length=hop_length)\n",
+    "\n",
+    "# To times\n",
+    "beat_times = librosa.frames_to_time(frames, sr=sr, \n",
+    "                                    hop_length=hop_length)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#  We will now save or beats to a JAMS file.\n",
+    "import jams\n",
+    "\n",
+    "jam = jams.JAMS()\n",
+    "jam.file_metadata.duration = len(audio_file)/sr\n",
+    "beat_a = jams.Annotation(namespace='beat')\n",
+    "beat_a.annotation_metadata = jams.AnnotationMetadata(data_source='librosa beat tracker')\n",
+    "\n",
+    "#  Add beat timings to the annotation record.\n",
+    "#  The beat namespace does not require value or confidence fields,\n",
+    "#  so we can leave those blank.\n",
+    "for t in beat_times:\n",
+    "    beat_a.append(time=t, duration=0.0)\n",
+    "\n",
+    "#  Store the new annotation in the jam file. This need to be located on the references folder\n",
+    "#  and be named like the audio file except for the jams extension.\n",
+    "jam.annotations.append(beat_a)\n",
+    "jam.save('../datasets/Sargon/references/01-Sargon-Mindless.jams')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#  Using the annotated beats then is straight forward.\n",
+    "#  Just be sure you don't have a temporary features file in the directory.\n",
+    "\n",
+    "boundaries, labels = msaf.process(audio_file, boundaries_id=\"foote\", \n",
+    "                                  annot_beats=True, labels_id=\"fmc2d\", plot=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Evaluate Results ###\n",
     "\n",
     "The results can be evaluated as long as there is an existing file containing reference annotations. The results are stored in a pandas DataFrame. MSAF has to run these algorithms (using `msaf.process` described above) before being able to evaluate its results."

--- a/msaf/base.py
+++ b/msaf/base.py
@@ -119,7 +119,7 @@ class Features(six.with_metaclass(MetaFeatures)):
         frames: np.array
             Frame indeces of estimated beats.
         """
-        # Compute harmonic-percussive source separiation if needed
+        # Compute harmonic-percussive source separation if needed
         if self._audio_percussive is None:
             self._audio_harmonic, self._audio_percussive = self.compute_HPSS()
 

--- a/msaf/run.py
+++ b/msaf/run.py
@@ -275,8 +275,7 @@ def process(in_path, annot_beats=False, feature="pcp", framesync=False,
         Input path. If a directory, MSAF will function in collection mode.
         If audio file, MSAF will be in single file mode.
     annot_beats: bool
-        Whether to use annotated beats or not. Only available in collection
-        mode.
+        Whether to use annotated beats or not.
     feature: str
         String representing the feature to be used (e.g. pcp, mfcc, tonnetz)
     framesync: str


### PR DESCRIPTION
I decided to use the librosa beat tracker because the implementation was readily available and it doesn't add any extra dependencies to the example notebook. 
It should be noted that after writing the reference files, the ground truth is lost. That's why I'm not using the same audio file that is used for the rest of the example.