### PR TITLE
replace `logamplitude` with `amplitude_to_db` to maintain compatibility with librosa v0.6.0

### DIFF
--- a/msaf/features.py
+++ b/msaf/features.py
@@ -92,7 +92,7 @@ class CQT(Features):
             self._audio, sr=self.sr, hop_length=self.hop_length,
             n_bins=self.n_bins, norm=self.norm, filter_scale=self.filter_scale,
             real=False)) ** 2
-        cqt = librosa.logamplitude(linear_cqt, ref_power=self.ref_power).T
+        cqt = librosa.amplitude_to_db(linear_cqt, ref_power=self.ref_power).T
         return cqt
 
 
@@ -163,7 +163,7 @@ class MFCC(Features):
                                            n_fft=self.n_fft,
                                            hop_length=self.hop_length,
                                            n_mels=self.n_mels)
-        log_S = librosa.logamplitude(S, ref_power=self.ref_power)
+        log_S = librosa.amplitude_to_db(S, ref_power=self.ref_power)
         mfcc = librosa.feature.mfcc(S=log_S, n_mfcc=self.n_mfcc).T
         return mfcc
 


### PR DESCRIPTION
Maintaining compatibility with librosa v.0.6.0 where `logamplitude` was replaced with `amplitude_to_db`: https://librosa.github.io/librosa/changelog.html?highlight=logamplitude

Thanks!