### PR TITLE
fix bug in find_estimation when labels_id is None

### DIFF
--- a/msaf/input_output.py
+++ b/msaf/input_output.py
@@ -187,7 +187,8 @@ def find_estimation(jam, boundaries_id, labels_id, params):
     ann = jam.search(namespace=namespace).\
         search(**{"Sandbox.boundaries_id": boundaries_id}).\
         search(**{"Sandbox.labels_id": lambda x:
-                  (isinstance(x, six.string_types) and
+                  (isinstance(labels_id, six.string_types) and
+                   isinstance(x, six.string_types) and
                    re.match(labels_id, x) is not None) or x is None})
     for key, val in zip(params.keys(), params.values()):
         if isinstance(val, six.string_types):


### PR DESCRIPTION
Hi,

The Collection Mode example in the Run MSAF notebook throws an exception because the first parameter to re.match() isn't a string or compiled regex. I am using Python 3.8.2 and fixed it by expanding the existing check in find_estimation. Not sure if this is the most elegant solution though.

Best regards,
Matthias