### PR TITLE
Set mandatory keyword arguments

### DIFF
--- a/msaf/base.py
+++ b/msaf/base.py
@@ -351,8 +351,8 @@ class Features(six.with_metaclass(MetaFeatures)):
     def _compute_framesync_times(self):
         """Computes the framesync times based on the framesync features."""
         self._framesync_times = librosa.core.frames_to_time(
-            np.arange(self._framesync_features.shape[0]), self.sr,
-            self.hop_length)
+            np.arange(self._framesync_features.shape[0]), sr=self.sr,
+            hop_length=self.hop_length)
 
     def _compute_all_features(self):
         """Computes all the features (beatsync, framesync) from the audio."""


### PR DESCRIPTION
### What?
Update librosa.frames_to_time call to use keyword arguments.

### Why?
MSAF doesn't work with librosa anymore as of https://github.com/librosa/librosa/pull/1431/files

```
TypeError: frames_to_time() takes 1 positional argument but 3 were given
```