### PR TITLE
Fix NumPy deprecation error

### DIFF
--- a/msaf/algorithms/scluster/main2.py
+++ b/msaf/algorithms/scluster/main2.py
@@ -130,10 +130,10 @@ def do_segmentation(C, M, config, in_bound_idxs=None):
         for k in range(1, config["num_layers"] + 1):
             est_idx, est_label = cluster(embedding, Cnorm, k)
             est_idxs.append(est_idx)
-            est_labels.append(np.asarray(est_label, dtype=np.int))
+            est_labels.append(np.asarray(est_label, dtype=np.int64))
 
     else:
         est_idxs, est_labels = cluster(embedding, Cnorm, config["scluster_k"], in_bound_idxs)
-        est_labels = np.asarray(est_labels, dtype=np.int)
+        est_labels = np.asarray(est_labels, dtype=np.int64)
 
     return est_idxs, est_labels, Cnorm

--- a/msaf/algorithms/sf/segmenter.py
+++ b/msaf/algorithms/sf/segmenter.py
@@ -146,7 +146,7 @@ class Segmenter(SegmenterInterface):
                 red = 0.1
                 F_copy = np.copy(F)
                 F = librosa.util.utils.sync(
-                         F.T, np.linspace(0, F.shape[0], num=int(F.shape[0] * red), dtype= np.int),
+                         F.T, np.linspace(0, F.shape[0], num=int(F.shape[0] * red), dtype= np.int64),
                          pad=False).T
 
             # Emedding the feature space (i.e. shingle)
@@ -182,7 +182,7 @@ class Segmenter(SegmenterInterface):
             est_bounds = np.asarray(est_bounds) + int(np.ceil(m / 2.))
 
             if self.framesync:
-                est_bounds = np.asarray(est_bounds // red, dtype=np.int)
+                est_bounds = np.asarray(est_bounds // red, dtype=np.int64)
                 F = F_copy
         else:
             est_bounds = []

--- a/msaf/algorithms/vmo/main.py
+++ b/msaf/algorithms/vmo/main.py
@@ -91,10 +91,10 @@ def scluster_segment(feature, config, in_bound_idxs=None):
         for k in range(1, config["hier_num_layers"] + 1):
             est_idx, est_label = cluster(embedding, Cnorm, k)
             est_idxs.append(est_idx)
-            est_labels.append(np.asarray(est_label, dtype=np.int))
+            est_labels.append(np.asarray(est_label, dtype=np.int64))
 
     else:
         est_idxs, est_labels = cluster(embedding, Cnorm, config["vmo_k"], in_bound_idxs)
-        est_labels = np.asarray(est_labels, dtype=np.int)
+        est_labels = np.asarray(est_labels, dtype=np.int64)
 
     return est_idxs, est_labels, Cnorm

--- a/msaf/pymf/sivm_gsat.py
+++ b/msaf/pymf/sivm_gsat.py
@@ -117,7 +117,7 @@ class SIVM_GSAT(SIVM):
         return False,-1
 
     def update_w(self):
-        n = np.int(np.floor(np.random.random() * self._num_samples))
+        n = np.int64(np.floor(np.random.random() * self._num_samples))
         if n not in self.select:
             updated, s = self.online_update_w(self.data[:,n])
             if updated:


### PR DESCRIPTION
As per https://numpy.org/devdocs/release/1.24.0-notes.html#expired-deprecations
these aliases are deprecated and now cause errors.