### PR TITLE
Remove pre-existing NumPy requirement from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 from setuptools import setup, find_packages
 import glob
 import imp
-import numpy.distutils.misc_util
 
 version = imp.load_source('msaf.version', 'msaf/version.py')
 
@@ -56,6 +55,5 @@ setup(
     ],
     extras_require={
         'resample': 'scikits.samplerate>=0.3'
-    },
-    include_dirs=numpy.distutils.misc_util.get_numpy_include_dirs()
+    }
 )


### PR DESCRIPTION
### What?
Make sure `msaf` can be installed in a new Python venv without first having to install NumPy.

### Why?
Noticed that there were C/C++ extensions used in the past by MSAF, which is why `import numpy` has been needed, I guess? Since there doesn't seem to be any such install steps anymore, it would be convenient to not have to 
```
pip install numpy
pip install msaf
```
in sequence anymore. Especially for users who doesn't use Anaconda and prefer miniconda and/or pip wheels.

### How?
This PR takes makes `python -m venv .venv; .venv/bin/pip install msaf` work by removing the import of numpy within the setup.py script.