### PR TITLE
Fix install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ See https://msaf.readthedocs.io for a complete reference manual and introductory
 
 From the root folder, type:
     
-    pip install msaf
+    pip install .
 
 (Note: you may need to prefix the previous line with `sudo`, depending on your system configuration).
 


### PR DESCRIPTION
Very minor nitpick that confused my students but running `pip install msaf` from the repo root actually installs the PyPI release of MSAF, and not the setup.py from the git checkout in the folder.