### PR TITLE
Remove broken shield

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ A Python framework to analyze music structure.
 
 [![PyPI version](https://badge.fury.io/py/msaf.svg)](https://badge.fury.io/py/msaf)
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/urinieto/msaf/master/LICENSE.md)
-[![Code Health](https://landscape.io/github/urinieto/msaf/master/landscape.svg?style=flat)](https://landscape.io/github/urinieto/msaf/master)
 [![Build Status](https://travis-ci.org/urinieto/msaf.svg?branch=master)](https://travis-ci.org/urinieto/msaf)
 [![Coverage Status](https://coveralls.io/repos/github/urinieto/msaf/badge.svg?branch=master)](https://coveralls.io/github/urinieto/msaf?branch=master)
 [![Documentation Status](https://readthedocs.org/projects/msaf/badge/?version=latest)](https://msaf.readthedocs.io/en/latest/?badge=latest)


### PR DESCRIPTION
Doesn't seem like landscape.io exists anymore, and the URL leads to a browser warning.