### PR TITLE
Create release.yaml for GitHub Actions based PyPI package releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,55 @@
+name: Build and publish Python packages to PyPI
+
+on:
+  workflow_dispatch:
+  release:
+    types:
+      - published
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version:
+          - "3.8"
+          - "3.9"
+          - "3.10"
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install build tool
+        run: pip install build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Upload package as build artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: package
+          path: dist/
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: pypi
+      url: https://pypi.org/p/msaf
+    permissions:
+      id-token: write
+    steps:
+      - name: Collect packages to release
+        uses: actions/download-artifact@v3
+        with:
+          name: package
+          path: dist/
+
+      - name: Publish packages to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/upload_to_pypi.sh
+++ b/upload_to_pypi.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env sh
-python setup.py egg_info
-python2 setup.py sdist bdist_wheel
-python3 setup.py sdist bdist_wheel
-pipreqs msaf/
-mv msaf/requirements.txt .
-twine upload dist/*


### PR DESCRIPTION
### What?
Introduce a package release workflow for building and distributing `msaf` to PyPI.

### Install workflow on PyPI
Login to https://pypi.org/manage/account/publishing/ and fill in GitHub.com repo details under "Add a new pending publisher" as per this screenshot:
<img width="807" alt="image" src="https://github.com/urinieto/msaf/assets/1595907/ac3c695d-0ff6-4aae-9b77-00421e357c1d">

### Usage of workflow on GitHub
1. Update package version in Python code.
2. Create a GitHub Releases release as repo owner here: https://github.com/urinieto/msaf/releases
3. Watch the GitHub Actions workflow run. Once ✅ the newly built package should be on PyPI here https://pypi.org/project/msaf/

### Examples
- https://pypi.org/project/gpt-engineer/ from https://github.com/AntonOsika/gpt-engineer/commit/e1ebe43cbc23fd209ef951c5c2cce48d05d56926 
- https://pypi.org/project/msaf-test/ from https://github.com/carlthome/msaf