### PR TITLE
Updated Reqs to work on latest Numpy 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,10 +4,10 @@ scipy==1.1.0
 mir_eval==0.4
 pandas==0.23.1
 librosa==0.6.1
+llvmlite==0.32.1
 six==1.11.0
-numpy==1.14.5
-matplotlib==2.2.2
-msaf==0.1.70
+numpy==1.19.5
+matplotlib==3.3.4
 scikit_learn==0.19.1
 numpydoc==0.8.0
 sphinx-rtd-theme==0.2.4


### PR DESCRIPTION
These reqs should work on Intel mac with Python=3.6