### PR TITLE
Use `cls` for classmethod argument

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -197,7 +197,7 @@ else:
 
 class Mock(MagicMock):
     @classmethod
-    def __getattr__(classname, x):
+    def __getattr__(cls, x):
         if x == "_mock_methods":
             return x._mock_methods
         else:

--- a/msaf/algorithms/fmc2d/xmeans.py
+++ b/msaf/algorithms/fmc2d/xmeans.py
@@ -175,7 +175,7 @@ class XMeans:
         return l_D - p / 2. * np.log(R)
 
     @classmethod
-    def generate_2d_data(self, N=100, K=5):
+    def generate_2d_data(cls, N=100, K=5):
         """Generates N*K 2D data points with K means and N data points
             for each mean."""
         # Seed the random

--- a/msaf/base.py
+++ b/msaf/base.py
@@ -492,6 +492,6 @@ class Features(six.with_metaclass(MetaFeatures)):
                                   "implementation of the features")
 
     @classmethod
-    def get_id(self):
+    def get_id(cls):
         raise NotImplementedError("This method must return a string identifier"
                                   " of the features")

--- a/msaf/features.py
+++ b/msaf/features.py
@@ -75,7 +75,7 @@ class CQT(Features):
             raise FeatureParamsError("Wrong value for ref_power")
 
     @classmethod
-    def get_id(self):
+    def get_id(cls):
         """Identifier of these features."""
         return "cqt"
 
@@ -145,7 +145,7 @@ class MFCC(Features):
             raise FeatureParamsError("Wrong value for ref_power")
 
     @classmethod
-    def get_id(self):
+    def get_id(cls):
         """Identifier of these features."""
         return "mfcc"
 
@@ -209,7 +209,7 @@ class PCP(Features):
         self.n_octaves = n_octaves
 
     @classmethod
-    def get_id(self):
+    def get_id(cls):
         """Identifier of these features."""
         return "pcp"
 
@@ -279,7 +279,7 @@ class Tonnetz(Features):
         self.n_octaves = n_octaves
 
     @classmethod
-    def get_id(self):
+    def get_id(cls):
         """Identifier of these features."""
         return "tonnetz"
 
@@ -329,7 +329,7 @@ class Tempogram(Features):
         self.win_length = win_length
 
     @classmethod
-    def get_id(self):
+    def get_id(cls):
         """Identifier of these features."""
         return "tempogram"
 


### PR DESCRIPTION
Minor polish but `self` is reserved for the instance, so classmethods should not take in `self` but rather `cls` like in:

https://github.com/urinieto/msaf/blob/7fcedb4e80b000cc60818caf54f0ba9abe3de3f5/msaf/base.py#L453

Stems out of seeing warnings from the Python extension in VS Code.