### PR TITLE
Log progress in collection mode

### DIFF
--- a/msaf/eval.py
+++ b/msaf/eval.py
@@ -378,7 +378,7 @@ def process(in_path, boundaries_id=msaf.config.default_bound_id,
 
         # Evaluate in parallel
         logging.info("Evaluating %d tracks..." % len(file_structs))
-        evals = Parallel(n_jobs=n_jobs)(delayed(process_track)(
+        evals = Parallel(n_jobs=n_jobs, verbose=2)(delayed(process_track)(
             file_struct, boundaries_id, labels_id, config,
             annotator_id=annotator_id) for file_struct in file_structs[:])
 

--- a/msaf/run.py
+++ b/msaf/run.py
@@ -363,6 +363,6 @@ def process(in_path, annot_beats=False, feature="pcp", framesync=False,
         # Collection mode
         file_structs = io.get_dataset_files(in_path)
 
-        return Parallel(n_jobs=n_jobs)(delayed(process_track)(
+        return Parallel(n_jobs=n_jobs, verbose=2)(delayed(process_track)(
             file_struct, boundaries_id, labels_id, config,
             annotator_id=annotator_id) for file_struct in file_structs[:])


### PR DESCRIPTION
Just a proposal (feel free to close!).

When running MSAF on SALAMI, it takes a while to process every feature, but there's no visible output during `msaf.run.process` in collection mode, so I thought my computer had frozen/crashed.

Would be nice to see some progress reporting with TQDM or similar. Turns out joblib already has support for printing some progress in the style of the following:

```sh
[Parallel(n_jobs=4)]: Using backend LokyBackend with 4 concurrent workers.
[Parallel(n_jobs=4)]: Done  33 tasks      | elapsed:    5.3s
[Parallel(n_jobs=4)]: Done 154 tasks      | elapsed:  1.1min
```

This PR enables that.