### PR TITLE
Allow custom features

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -8,6 +8,7 @@ Contributors
 * Keunwoo Choi <https://github.com/keunwoochoi>
 * Rustam S <https://github.com/fortunto2>
 * Cheng-i Wang <https://github.com/wangsix>
+* Carl Thomé <https://github.com/carlthome>
 
 OLDA and Laplacian algorithm implementations were forked from the original repos by the titanest Brian McFee:
 <https://github.com/bmcfee/olda> and <https://github.com/bmcfee/laplacian_segmentation>, respectively.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ From the root folder, type:
 
 ## Demonstration Notebook ##
 
-You can follow a thorough example on this titanic [Jupyter Notebook](https://github.com/urinieto/msaf/blob/master/examples/Run%20MSAF.ipynb).
+You can follow a thorough example on this titanic [Jupyter Notebook](https://github.com/urinieto/msaf/blob/main/examples/Run%20MSAF.ipynb).
 
 ## Citing MSAF ##
 

--- a/docs/eval.rst
+++ b/docs/eval.rst
@@ -10,7 +10,7 @@ These metrics are computed using the external and fantastic framework `mir_eval 
 How To Evaluate Results
 -----------------------
 
-The module `eval.py <https://github.com/urinieto/msaf/blob/master/msaf/eval.py>`_ contains the following ``process`` function that can be called once the desired algorithms have been run on a single file or dataset:
+The module `eval.py <https://github.com/urinieto/msaf/blob/main/msaf/eval.py>`_ contains the following ``process`` function that can be called once the desired algorithms have been run on a single file or dataset:
 
 .. automodule:: msaf.eval
 
@@ -23,17 +23,17 @@ Boundary Metrics
 =================  ==============
 Boundary Metric    Description
 =================  ==============
-D                  Information Gain  
-DevE2R             Median Deviation from Estimation to Reference 
-DevR2E             Median Deviation from Reference to Estimation 
+D                  Information Gain
+DevE2R             Median Deviation from Estimation to Reference
+DevR2E             Median Deviation from Reference to Estimation
 DevtE2R            Median Deviation from Estimation to Reference without first and last boundaries (trimmed)
 DevtR2E            Median Deviation from Reference to Estimation without first and last boundaries (trimmed)
-HitRate\_0.5F      Hit Rate F-measure using 0.5 seconds window 
-HitRate\_0.5P      Hit Rate Precision using 0.5 seconds window 
-HitRate\_0.5R      Hit Rate Recall using 0.5 seconds window 
-HitRate\_3F        Hit Rate F-measure using 3 seconds window 
-HitRate\_3P        Hit Rate Precision using 3 seconds window 
-HitRate\_3R        Hit Rate Recall using 3 seconds window 
+HitRate\_0.5F      Hit Rate F-measure using 0.5 seconds window
+HitRate\_0.5P      Hit Rate Precision using 0.5 seconds window
+HitRate\_0.5R      Hit Rate Recall using 0.5 seconds window
+HitRate\_3F        Hit Rate F-measure using 3 seconds window
+HitRate\_3P        Hit Rate Precision using 3 seconds window
+HitRate\_3R        Hit Rate Recall using 3 seconds window
 HitRate\_t0.5F     Hit Rate F-measure using 0.5 seconds window without first and last boundaries (trimmed)
 HitRate\_t0.5P     Hit Rate Precision using 0.5 seconds window without first and last boundaries (trimmed)
 HitRate\_t0.5R     Hit Rate Recall using 0.5 seconds window without first and last boundaries (trimmed)
@@ -54,10 +54,10 @@ Label Metrics
 =================  ==============
 Label Metric       Description
 =================  ==============
-PWF                Pairwise Frame Clustering F-measure 
-PWP                Pairwise Frame Clustering Precision 
-PWR                Pairwise Frame Clustering Recall 
-Sf                 Normalized Entropy Scores F-measure 
-So                 Normalized Entropy Scores Precision 
-Su                 Normalized Entropy Scores Recall 
+PWF                Pairwise Frame Clustering F-measure
+PWP                Pairwise Frame Clustering Precision
+PWR                Pairwise Frame Clustering Recall
+Sf                 Normalized Entropy Scores F-measure
+So                 Normalized Entropy Scores Precision
+Su                 Normalized Entropy Scores Recall
 =================  ==============

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -88,11 +88,11 @@ Adding New Features to MSAF
 MSAF is written such that adding new features should be relatively painless.
 Follow these steps:
 
-    1. Add a new class that inherits from ``Features`` in the file `features.py <https://github.com/urinieto/msaf/blob/master/msaf/features.py>`_.
+    1. Add a new class that inherits from ``Features`` in the file `features.py <https://github.com/urinieto/msaf/blob/main/msaf/features.py>`_.
     2. Implement the following methods: ``__init``, ``get_id``, and ``compute_features``:
 
         * ``__init__``: The constructor should accept the necessary parameters for the computation of the features, plus the ``file_struct`` (the audio file encapsulated in the `FileStruct` class), and ``feat_type`` (the type of features).
         * ``get_id``: Class method that returns the identifier of the new type of features.
         * ``compute_features``: The actual implementation of the features. Here the parameters of the constructor should be read.
 
-In the `features.py <https://github.com/urinieto/msaf/blob/master/msaf/features.py>`_ file the existing features of MSAF are found, which can be used as starting points. See `custom_feature.py <https://github.com/urinieto/msaf/blob/master/examples/custom_feature.py>`_ for a complete example.
+In the `features.py <https://github.com/urinieto/msaf/blob/main/msaf/features.py>`_ file the existing features of MSAF are found, which can be used as starting points. See `custom_feature.py <https://github.com/urinieto/msaf/blob/main/examples/custom_feature.py>`_ for a complete example.

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -3,7 +3,7 @@
 Features
 ========
 
-Multiple audio features are available in MSAF, mostly implemented using 
+Multiple audio features are available in MSAF, mostly implemented using
 `librosa <https://github.com/librosa/librosa>`_.
 This framework is written such that they should only be computed once for each audio file.
 These features could potentially be used across all algorithms, so MSAF stores them in ``json``
@@ -21,16 +21,16 @@ The format of the ``json`` file is as follows:
 
     {
         "globals": {
-            "audio_file": "<path to audio file>", 
-            "dur": "<duration of audio>", 
-            "sample_rate": "<sample rate>", 
+            "audio_file": "<path to audio file>",
+            "dur": "<duration of audio>",
+            "sample_rate": "<sample rate>",
             "hop_length": "<hop lenght>"
-        }, 
+        },
         "metadata": {
-            "timestamp": "<YYYY/MM/DD hh:mm:ss>", 
+            "timestamp": "<YYYY/MM/DD hh:mm:ss>",
             "versions": {
-                "numpy": "<numpy version>", 
-                "msaf": "<msaf version>", 
+                "numpy": "<numpy version>",
+                "msaf": "<msaf version>",
                 "librosa": "<librosa version>"
             }
         }
@@ -48,10 +48,10 @@ The format of the ``json`` file is as follows:
                 "..."
             ],
             "params": {
-                "<param_name1>": "<param_value2>", 
-                "<param_name1>": "<param_value2>", 
+                "<param_name1>": "<param_value2>",
+                "<param_name1>": "<param_value2>",
                 "..."
-            } 
+            }
         }
         "est_beatsync_times": [ 0.0, 1.0, "..." ],
         "ann_beatsync_times": [ 0.0, 1.0, "..." ],
@@ -95,4 +95,4 @@ Follow these steps:
         * ``get_id``: Class method that returns the identifier of the new type of features.
         * ``compute_features``: The actual implementation of the features. Here the parameters of the constructor should be read.
 
-In the `features.py <https://github.com/urinieto/msaf/blob/master/msaf/features.py>`_ file the existing features of MSAF are found, which can be used as examples.
+In the `features.py <https://github.com/urinieto/msaf/blob/master/msaf/features.py>`_ file the existing features of MSAF are found, which can be used as starting points. See `custom_feature.py <https://github.com/urinieto/msaf/blob/master/examples/custom_feature.py>`_ for a complete example.

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -18,7 +18,7 @@ MSAF is divided into the four different moving blocks that compose the music str
 		in this module of MSAF.
 	- :ref:`Datasets <datasets>`:
 		A series of human-annotated datasets to benchmark algorithms.
-		Note: these data must be downloaded separately from here: 
+		Note: these data must be downloaded separately from here:
 		`<https://github.com/urinieto/msaf-data>`_
 
 .. _quickstart_example:
@@ -56,7 +56,7 @@ Let's begin with a simple example program:
         print("No references found in {}. No evaluation performed.".format(
             file_struct.ref_file))
 
-In the first step we select the appropriate audio file. 
+In the first step we select the appropriate audio file.
 The MSAF `datasets <https://github.com/urinieto/msaf-data>`_ contain the Sargon set, which has multiple audio files to play around. ::
 
     audio_file = "../datasets/Sargon/audio/01-Sargon-Mindless.mp3"
@@ -181,8 +181,8 @@ More Examples
 
 In the `examples <https://github.com/urinieto/msaf/tree/master/examples>`_ folder, more examples of using MSAF can be found.
 
-Included in that folder you can find a `Jupyter Notebook <https://github.com/urinieto/msaf/blob/master/examples/Run%20MSAF.ipynb>`_ with further interactive MSAF usage.
+Included in that folder you can find a `Jupyter Notebook <https://github.com/urinieto/msaf/blob/main/examples/Run%20MSAF.ipynb>`_ with further interactive MSAF usage.
 
 For more information about MSAF, please refer to the original publication:
-    
+
     Nieto, O., Bello, J. P., Systematic Exploration Of Computational Music Structure Research. Proc. of the 17th International Society for Music Information Retrieval Conference (ISMIR). New York City, NY, USA, 2016 (`PDF <http://marl.smusic.nyu.edu/nieto/publications/ISMIR2016-NietoBello.pdf>`_).

--- a/examples/custom_feature.py
+++ b/examples/custom_feature.py
@@ -34,7 +34,7 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("in_path", help="audio file")
     args = parser.parse_args()
-    results = msaf.run.process(args.in_path, feature="my_features")
+    results = msaf.run.process(args.in_path, feature=MyFeatures)
     print(results)
 
 

--- a/examples/custom_feature.py
+++ b/examples/custom_feature.py
@@ -1,0 +1,42 @@
+import argparse
+import librosa
+import msaf
+
+
+class MyFeatures(msaf.features.Features):
+    def __init__(
+        self,
+        file_struct,
+        feat_type,
+        sr=msaf.config.sample_rate,
+        hop_length=msaf.config.hop_size,
+    ):
+        super().__init__(
+            file_struct=file_struct, sr=sr, hop_length=hop_length, feat_type=feat_type
+        )
+
+    @classmethod
+    def get_id(cls):
+        return "my_features"
+
+    def compute_features(self):
+        features = librosa.feature.chroma_vqt(
+            y=self._audio,
+            sr=self.sr,
+            hop_length=self.hop_length,
+            intervals="pythagorean",
+        )
+        features = features.T  # (num_frames, num_features)
+        return features
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("in_path", help="audio file")
+    args = parser.parse_args()
+    results = msaf.run.process(args.in_path, feature="my_features")
+    print(results)
+
+
+if __name__ == "__main__":
+    main()

--- a/msaf/algorithms/interface.py
+++ b/msaf/algorithms/interface.py
@@ -84,20 +84,13 @@ class SegmenterInterface:
         raise NotImplementedError("This method does not return hierarchical "
                                   "segmentations.")
 
-    def _preprocess(self, valid_features=["pcp", "tonnetz", "mfcc",
-                                          "cqt", "tempogram"]):
+    def _preprocess(self):
         """This method obtains the actual features."""
-        # Use specific feature
-        if self.feature_str not in valid_features:
-            raise RuntimeError("Feature %s in not valid for algorithm: %s "
-                               "(valid features are %s)." %
-                               (self.feature_str, __name__, valid_features))
-        else:
-            try:
-                F = self.features.features
-            except KeyError:
-                raise RuntimeError("Feature %s in not supported by MSAF" %
-                                   (self.feature_str))
+        try:
+            F = self.features.features
+        except KeyError:
+            raise RuntimeError("Feature %s in not supported by MSAF" % 
+                               (self.feature_str))
 
         return F
 

--- a/msaf/base.py
+++ b/msaf/base.py
@@ -455,7 +455,7 @@ class Features(metaclass=MetaFeatures):
 
         Parameters
         ----------
-        features_id: str
+        features_id: str or `msaf.features.Features` class
             The identifier of the features (it must be a key inside the
             `features_registry`)
         file_struct: msaf.io.FileStruct
@@ -480,12 +480,16 @@ class Features(metaclass=MetaFeatures):
             raise FeatureTypeNotFound("Type of features not valid.")
 
         # Select features with default parameters
-        if features_id not in features_registry.keys():
+        if features_id in features_registry.keys():
+            feature = features_registry[features_id]
+        elif isinstance(features_id, MetaFeatures) and issubclass(features_id, Features):
+            feature = features_id
+        else:
             raise FeaturesNotFound(
                 "The features '%s' are invalid (valid features are %s)"
                 % (features_id, features_registry.keys()))
 
-        return features_registry[features_id](file_struct, feat_type)
+        return feature(file_struct, feat_type)
 
     def compute_features(self):
         raise NotImplementedError("This method must contain the actual "

--- a/msaf/input_output.py
+++ b/msaf/input_output.py
@@ -190,6 +190,8 @@ def find_estimation(jam, boundaries_id, labels_id, params):
     for key, val in zip(params.keys(), params.values()):
         if isinstance(val, str):
             ann = ann.search(**{"Sandbox.%s" % key: val})
+        elif isinstance(val, msaf.base.MetaFeatures):
+            ann = ann.search(**{"Sandbox.%s" % key: lambda x: x == val.get_id()})
         else:
             ann = ann.search(**{"Sandbox.%s" % key: lambda x: x == val})
 
@@ -281,8 +283,10 @@ def save_estimations(file_struct, times, labels, boundaries_id, labels_id,
     sandbox["labels_id"] = labels_id
     sandbox["timestamp"] = \
         datetime.datetime.today().strftime("%Y/%m/%d %H:%M:%S")
-    for key in params:
-        sandbox[key] = params[key]
+    for key, value in params.items():
+        if isinstance(value, msaf.base.MetaFeatures):
+            value = value.get_id()
+        sandbox[key] = value
     ann.sandbox = sandbox
 
     # Save actual data


### PR DESCRIPTION
Trying to implement a new feature by implementing `Features` but unable to use it with `msaf.run.process` because there's a hardcoded list of feature names in `_preprocess` in the `SegmenterInterface` that's not exposed to the user (as far as I can see).

Maybe I'm missing something in the docs but think this check could simply be removed, and the `try/except` covers any potential problems on its own.

Bit unsure of this though. Gladly take help!