### PR TITLE
Save sonified audio at 16-bit instead of 64-bit

### DIFF
--- a/msaf/utils.py
+++ b/msaf/utils.py
@@ -147,7 +147,7 @@ def sonify_clicks(audio, clicks, out_file, fs, offset=0):
     out_audio[:len(audio)] = audio
     out_audio[:len(audio_clicks)] += audio_clicks
 
-    # Convert audio to 16-bit
+    # Convert audio to 16-bit signed integer
     amplitude = np.iinfo(np.int16).max
     data = (amplitude * out_audio).astype(np.int16)
 

--- a/msaf/utils.py
+++ b/msaf/utils.py
@@ -147,8 +147,12 @@ def sonify_clicks(audio, clicks, out_file, fs, offset=0):
     out_audio[:len(audio)] = audio
     out_audio[:len(audio_clicks)] += audio_clicks
 
+    # Convert audio to 16-bit
+    amplitude = np.iinfo(np.int16).max
+    data = (amplitude * out_audio).astype(np.int16)
+
     # Write to file
-    scipy.io.wavfile.write(out_file, fs, out_audio)
+    scipy.io.wavfile.write(out_file, fs, data)
 
 
 def synchronize_labels(new_bound_idxs, old_bound_idxs, old_labels, N):

--- a/msaf/utils.py
+++ b/msaf/utils.py
@@ -147,6 +147,9 @@ def sonify_clicks(audio, clicks, out_file, fs, offset=0):
     out_audio[:len(audio)] = audio
     out_audio[:len(audio_clicks)] += audio_clicks
 
+    # Peak normalize the mix
+    out_audio /= np.abs(out_audio).max()
+
     # Convert audio to 16-bit signed integer
     amplitude = np.iinfo(np.int16).max
     data = (amplitude * out_audio).astype(np.int16)


### PR DESCRIPTION
Minor thing but with `sonify_bounds` set, the extra output audio file is really large (a 5 minute music track is around 60 MB even at only 22.05 kHz).

Reason is `scipy.io.wavfile.write` respects the dtype of its input array, which is always doubles in NumPy when left unspecified.

This PR adds the bit depth conversion from `scipy.io.wavfile.write`'s docstring (60 MB -> 15 MB).