### PR TITLE
Fix OSError in tests

### DIFF
--- a/msaf/features.py
+++ b/msaf/features.py
@@ -64,9 +64,9 @@ class CQT(Features):
         self.norm = norm
         self.filter_scale = filter_scale
         if ref_power == "max":
-            self.ref_power = np.max
+            self.ref_power = np.amax
         elif ref_power == "min":
-            self.ref_power = np.min
+            self.ref_power = np.amin
         elif ref_power == "median":
             self.ref_power = np.median
         else:
@@ -134,9 +134,9 @@ class MFCC(Features):
         self.n_mels = n_mels
         self.n_mfcc = n_mfcc
         if ref_power == "max":
-            self.ref_power = np.max
+            self.ref_power = np.amax
         elif ref_power == "min":
-            self.ref_power = np.min
+            self.ref_power = np.amin
         elif ref_power == "median":
             self.ref_power = np.median
         else:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,17 +1,14 @@
-#!/usr/bin/env python
-# For plotting and testing
-import matplotlib
-matplotlib.use('Agg')
-matplotlib.rcParams.update(matplotlib.rcParamsDefault)
-
-from pytest import raises
 from collections import namedtuple
 
-# Msaf imports
-import msaf
+import matplotlib
+from pytest import raises
 
-from msaf.configparser import (AddConfigVar, BoolParam, EnumStr,
-                               IntParam, StrParam, ListParam)
+import msaf
+from msaf.configparser import (AddConfigVar, BoolParam, EnumStr, IntParam,
+                               ListParam, StrParam)
+
+matplotlib.use('Agg')
+matplotlib.rcParams.update(matplotlib.rcParamsDefault)
 
 
 def test_print_config():

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -1,12 +1,10 @@
-#!/usr/bin/env python
-"""Unit tests for eval."""
-
-from pytest import raises
-import numpy.testing as npt
-import numpy as np
 import os
-import pandas as pd
 import shutil
+
+import numpy as np
+import numpy.testing as npt
+import pandas as pd
+from pytest import raises
 
 import msaf
 import msaf.eval as E

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -9,8 +9,7 @@ from pytest import raises
 # Msaf imports
 import msaf
 from msaf.base import FeatureTypes
-from msaf.exceptions import (FeatureParamsError, FeatureTypeNotFound,
-                             NoAudioFileError)
+from msaf.exceptions import FeatureParamsError, FeatureTypeNotFound, NoAudioFileError
 from msaf.features import CQT, MFCC, PCP, Features, Tempogram, Tonnetz
 from msaf.input_output import FileStruct
 
@@ -29,11 +28,11 @@ except OSError:
 
 def test_registry():
     """All the features should be in the features register."""
-    assert(CQT.get_id() in msaf.base.features_registry.keys())
-    assert(PCP.get_id() in msaf.base.features_registry.keys())
-    assert(Tonnetz.get_id() in msaf.base.features_registry.keys())
-    assert(MFCC.get_id() in msaf.base.features_registry.keys())
-    assert(Tempogram.get_id() in msaf.base.features_registry.keys())
+    assert CQT.get_id() in msaf.base.features_registry.keys()
+    assert PCP.get_id() in msaf.base.features_registry.keys()
+    assert Tonnetz.get_id() in msaf.base.features_registry.keys()
+    assert MFCC.get_id() in msaf.base.features_registry.keys()
+    assert Tempogram.get_id() in msaf.base.features_registry.keys()
 
 
 def run_framesync(features_class):
@@ -42,27 +41,24 @@ def run_framesync(features_class):
     the json file."""
     feat_type = FeatureTypes.framesync
     feats = features_class(file_struct, feat_type).features
-    assert (os.path.isfile(file_struct.features_file))
+    assert os.path.isfile(file_struct.features_file)
     with open(file_struct.features_file) as f:
         data = json.load(f)
-    assert(features_class.get_id() in data.keys())
-    assert("framesync" in data[features_class.get_id()].keys())
-    assert("est_beatsync" in data[features_class.get_id()].keys())
-    assert("ann_beatsync" in data[features_class.get_id()].keys())
+    assert features_class.get_id() in data.keys()
+    assert "framesync" in data[features_class.get_id()].keys()
+    assert "est_beatsync" in data[features_class.get_id()].keys()
+    assert "ann_beatsync" in data[features_class.get_id()].keys()
     read_feats = np.array(data[features_class.get_id()]["framesync"])
-    assert(np.array_equal(feats, read_feats))
+    assert np.array_equal(feats, read_feats)
 
 
 def run_ref_power(features_class):
-    feats = features_class(file_struct, FeatureTypes.framesync,
-                           ref_power="max")
-    assert(feats.ref_power.__code__.co_code == np.max.__code__.co_code)
-    feats = features_class(file_struct, FeatureTypes.framesync,
-                           ref_power="min")
-    assert(feats.ref_power.__code__.co_code == np.min.__code__.co_code)
-    feats = features_class(file_struct, FeatureTypes.framesync,
-                           ref_power="median")
-    assert(feats.ref_power.__code__.co_code == np.median.__code__.co_code)
+    feats = features_class(file_struct, FeatureTypes.framesync, ref_power="max")
+    assert feats.ref_power.__code__.co_code == np.max.__code__.co_code
+    feats = features_class(file_struct, FeatureTypes.framesync, ref_power="min")
+    assert feats.ref_power.__code__.co_code == np.min.__code__.co_code
+    feats = features_class(file_struct, FeatureTypes.framesync, ref_power="median")
+    assert feats.ref_power.__code__.co_code == np.median.__code__.co_code
 
 
 def test_standard_cqt():
@@ -120,12 +116,12 @@ def test_metadata():
     # Note: The json file should have been created with previous tests
     with open(file_struct.features_file) as f:
         data = json.load(f)
-    assert("metadata" in data.keys())
+    assert "metadata" in data.keys()
     metadata = data["metadata"]
-    assert("timestamp" in metadata.keys())
-    assert(metadata["versions"]["numpy"] == np.__version__)
-    assert(metadata["versions"]["msaf"] == msaf.__version__)
-    assert(metadata["versions"]["librosa"] == librosa.__version__)
+    assert "timestamp" in metadata.keys()
+    assert metadata["versions"]["numpy"] == np.__version__
+    assert metadata["versions"]["msaf"] == msaf.__version__
+    assert metadata["versions"]["librosa"] == librosa.__version__
 
 
 def test_change_local_cqt_paramaters():
@@ -133,19 +129,19 @@ def test_change_local_cqt_paramaters():
     updated."""
     feat_type = FeatureTypes.framesync
     CQT(file_struct, feat_type, n_bins=70).features
-    assert (os.path.isfile(file_struct.features_file))
+    assert os.path.isfile(file_struct.features_file)
     with open(file_struct.features_file) as f:
         data = json.load(f)
-    assert(CQT.get_id() in data.keys())
+    assert CQT.get_id() in data.keys()
 
     # These should be here from previous tests
-    assert(MFCC.get_id() in data.keys())
-    assert(Tonnetz.get_id() in data.keys())
-    assert(Tempogram.get_id() in data.keys())
-    assert(PCP.get_id() in data.keys())
-    assert("framesync" in data[CQT.get_id()].keys())
-    assert("est_beatsync" in data[CQT.get_id()].keys())
-    assert("ann_beatsync" in data[CQT.get_id()].keys())
+    assert MFCC.get_id() in data.keys()
+    assert Tonnetz.get_id() in data.keys()
+    assert Tempogram.get_id() in data.keys()
+    assert PCP.get_id() in data.keys()
+    assert "framesync" in data[CQT.get_id()].keys()
+    assert "est_beatsync" in data[CQT.get_id()].keys()
+    assert "ann_beatsync" in data[CQT.get_id()].keys()
 
 
 def test_change_global_paramaters():
@@ -153,19 +149,19 @@ def test_change_global_paramaters():
     updated."""
     feat_type = FeatureTypes.framesync
     CQT(file_struct, feat_type, sr=11025).features
-    assert (os.path.isfile(file_struct.features_file))
+    assert os.path.isfile(file_struct.features_file)
     with open(file_struct.features_file) as f:
         data = json.load(f)
-    assert(CQT.get_id() in data.keys())
+    assert CQT.get_id() in data.keys()
 
     # These should have disappeared, since we now have new global parameters
-    assert(MFCC.get_id() not in data.keys())
-    assert(Tonnetz.get_id() not in data.keys())
-    assert(Tempogram.get_id() not in data.keys())
-    assert(PCP.get_id() not in data.keys())
-    assert("framesync" in data[CQT.get_id()].keys())
-    assert("est_beatsync" in data[CQT.get_id()].keys())
-    assert("ann_beatsync" in data[CQT.get_id()].keys())
+    assert MFCC.get_id() not in data.keys()
+    assert Tonnetz.get_id() not in data.keys()
+    assert Tempogram.get_id() not in data.keys()
+    assert PCP.get_id() not in data.keys()
+    assert "framesync" in data[CQT.get_id()].keys()
+    assert "est_beatsync" in data[CQT.get_id()].keys()
+    assert "ann_beatsync" in data[CQT.get_id()].keys()
 
 
 def test_no_audio():
@@ -176,10 +172,10 @@ def test_no_audio():
     no_audio_file_struct.features_file = "features/chirp_noaudio.json"
     feat_type = FeatureTypes.framesync
     CQT(no_audio_file_struct, feat_type, sr=22050).features
-    assert (os.path.isfile(no_audio_file_struct.features_file))
+    assert os.path.isfile(no_audio_file_struct.features_file)
     with open(no_audio_file_struct.features_file) as f:
         data = json.load(f)
-    assert(CQT.get_id() in data.keys())
+    assert CQT.get_id() in data.keys()
 
 
 def test_no_audio_no_params():
@@ -230,8 +226,7 @@ def test_wrong_type_features():
     """Trying to use custom type for features."""
     my_file_struct = FileStruct(os.path.join("fixtures", "chirp.mp3"))
     my_file_struct.features_file = os.path.join("features", "no_file.json")
-    FeatureTypes2 = Enum('FeatureTypes',
-                         'framesync1 est_beatsync ann_beatsync')
+    FeatureTypes2 = Enum("FeatureTypes", "framesync1 est_beatsync ann_beatsync")
     cqt = CQT(my_file_struct, FeatureTypes2.framesync1, sr=11025)
     with raises(FeatureTypeNotFound):
         cqt.features
@@ -241,8 +236,7 @@ def test_wrong_type_frame_times():
     """Trying to use custom type for frame times."""
     my_file_struct = FileStruct(os.path.join("fixtures", "chirp.mp3"))
     my_file_struct.features_file = os.path.join("features", "no_file.json")
-    FeatureTypes2 = Enum('FeatureTypes',
-                         'framesync1 est_beatsync ann_beatsync')
+    FeatureTypes2 = Enum("FeatureTypes", "framesync1 est_beatsync ann_beatsync")
     cqt = CQT(my_file_struct, FeatureTypes2.framesync1, sr=11025)
     with raises(FeatureTypeNotFound):
         cqt.frame_times
@@ -272,7 +266,7 @@ def test_frame_times_framesync():
     my_file_struct = FileStruct(os.path.join("fixtures", "chirp.mp3"))
     pcp = PCP(my_file_struct, FeatureTypes.framesync, sr=11025)
     times = pcp.frame_times
-    assert(isinstance(times, np.ndarray))
+    assert isinstance(times, np.ndarray)
 
 
 def test_frame_times_no_annotations():
@@ -326,8 +320,7 @@ def test_wrong_select_features():
 
 def test_read_features_wrong_fun():
     my_file_struct = FileStruct("01_-_Come_Together.wav")
-    my_file_struct.features_file = os.path.join(
-        "fixtures", "01_-_Come_Together.json")
+    my_file_struct.features_file = os.path.join("fixtures", "01_-_Come_Together.json")
     mfcc = MFCC(my_file_struct, FeatureTypes.est_beatsync, sr=22050)
     mfcc.ref_power = np.mean
     with raises(FeatureParamsError):

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,18 +1,17 @@
-#!/usr/bin/env python
-
-from enum import Enum
 import json
-import librosa
-from pytest import raises
-import numpy as np
 import os
+from enum import Enum
+
+import librosa
+import numpy as np
+from pytest import raises
 
 # Msaf imports
 import msaf
 from msaf.base import FeatureTypes
-from msaf.exceptions import (NoAudioFileError, FeatureParamsError,
-                             FeatureTypeNotFound)
-from msaf.features import CQT, PCP, Tonnetz, MFCC, Tempogram, Features
+from msaf.exceptions import (FeatureParamsError, FeatureTypeNotFound,
+                             NoAudioFileError)
+from msaf.features import CQT, MFCC, PCP, Features, Tempogram, Tonnetz
 from msaf.input_output import FileStruct
 
 # Global vars

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -54,9 +54,9 @@ def run_framesync(features_class):
 
 def run_ref_power(features_class):
     feats = features_class(file_struct, FeatureTypes.framesync, ref_power="max")
-    assert feats.ref_power == np.max
+    assert feats.ref_power == np.amax
     feats = features_class(file_struct, FeatureTypes.framesync, ref_power="min")
-    assert feats.ref_power == np.min
+    assert feats.ref_power == np.amin
     feats = features_class(file_struct, FeatureTypes.framesync, ref_power="median")
     assert feats.ref_power == np.median
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -54,11 +54,11 @@ def run_framesync(features_class):
 
 def run_ref_power(features_class):
     feats = features_class(file_struct, FeatureTypes.framesync, ref_power="max")
-    assert feats.ref_power.__code__.co_code == np.max.__code__.co_code
+    assert feats.ref_power == np.max
     feats = features_class(file_struct, FeatureTypes.framesync, ref_power="min")
-    assert feats.ref_power.__code__.co_code == np.min.__code__.co_code
+    assert feats.ref_power == np.min
     feats = features_class(file_struct, FeatureTypes.framesync, ref_power="median")
-    assert feats.ref_power.__code__.co_code == np.median.__code__.co_code
+    assert feats.ref_power == np.median
 
 
 def test_standard_cqt():

--- a/tests/test_fmc2d.py
+++ b/tests/test_fmc2d.py
@@ -1,7 +1,6 @@
-from pytest import raises
 import numpy as np
+from pytest import raises
 
-# Msaf imports
 from msaf.algorithms import fmc2d
 
 

--- a/tests/test_input_output.py
+++ b/tests/test_input_output.py
@@ -1,17 +1,11 @@
-#!/usr/bin/env python
-#
-# Run me as follows:
-# cd tests/
-# nosetests
-
-import jams
-import librosa
-from pytest import raises
-import numpy as np
 import os
 import shutil
 
-# Msaf imports
+import jams
+import librosa
+import numpy as np
+from pytest import raises
+
 import msaf
 from msaf.input_output import FileStruct
 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,26 +1,18 @@
-#!/usr/bin/env python
-#
-# Run me as follows:
-# cd tests/
-# nosetests
-
-# For plotting and testing
-import matplotlib
-matplotlib.use('Agg')
-matplotlib.rcParams.update(matplotlib.rcParamsDefault)
-import matplotlib.style
-
-from pytest import raises
-import numpy.testing as npt
 import os
 from types import ModuleType
 
-# Msaf imports
-import msaf
-from msaf.features import Features
-from msaf.exceptions import (NoHierBoundaryError, FeaturesNotFound,
-                             NoAudioFileError)
+import matplotlib
+import matplotlib.style
+import numpy.testing as npt
+from pytest import raises
 
+import msaf
+from msaf.exceptions import (FeaturesNotFound, NoAudioFileError,
+                             NoHierBoundaryError)
+from msaf.features import Features
+
+matplotlib.use('Agg')
+matplotlib.rcParams.update(matplotlib.rcParamsDefault)
 
 # Global vars
 audio_file = os.path.join("fixtures", "chirp.mp3")

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -9,7 +9,6 @@ import matplotlib
 matplotlib.use('Agg')
 matplotlib.rcParams.update(matplotlib.rcParamsDefault)
 import matplotlib.style
-matplotlib.style.use('seaborn-ticks')
 
 from pytest import raises
 import numpy.testing as npt

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,12 +1,9 @@
-# Run me as follows:
-# cd tests/
-# nosetests -v -s test_utils.py
 import copy
-import librosa
-import numpy as np
 import os
 
-# Msaf imports
+import librosa
+import numpy as np
+
 import msaf
 
 # Global vars


### PR DESCRIPTION
Recent matplotlib and seaborn produce
```
ERROR test_run.py - OSError: 'seaborn-ticks' is not a valid package style, path of style file, URL of style file, or library style name (library styles are listed in `style.available`)
```
when running the tests.

This PR works around that by simply not setting that style anymore. Perhaps more digging would be prefered though? Let me know and I'll try to understand this error better!

Also made sure `import` happens first in the test modules. Just a minor thing. Can remove this if prefered!