### PR TITLE
Group imports by standard library, third-party packages, first-party modules

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,6 +12,7 @@
 
 import os
 import sys
+
 import sphinx
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -144,6 +145,7 @@ copyright = '2015-2018, msaf development team'
 #
 
 import imp
+
 msaf = imp.load_source('msaf.version', '../msaf/version.py')
 # The short X.Y version.
 version = msaf.short_version

--- a/examples/compute_features.py
+++ b/examples/compute_features.py
@@ -14,11 +14,11 @@ Examples:
 """
 
 import argparse
-from joblib import Parallel, delayed
 import logging
 import os
 import time
 
+from joblib import Parallel, delayed
 
 import msaf
 from msaf.features import Features

--- a/examples/compute_features.py
+++ b/examples/compute_features.py
@@ -19,7 +19,7 @@ import logging
 import os
 import time
 
-# Local stuff
+
 import msaf
 from msaf.features import Features
 

--- a/examples/custom_feature.py
+++ b/examples/custom_feature.py
@@ -1,5 +1,7 @@
 import argparse
+
 import librosa
+
 import msaf
 
 

--- a/examples/run_msaf.py
+++ b/examples/run_msaf.py
@@ -9,7 +9,6 @@ import time
 # MSAF import
 import msaf
 
-
 if __name__ == '__main__':
     """Main function to parse the arguments and call the main process."""
     parser = argparse.ArgumentParser(

--- a/examples/run_sweep.py
+++ b/examples/run_sweep.py
@@ -3,8 +3,9 @@
 import argparse
 import logging
 import time
-import pandas as pd
+
 import numpy as np
+import pandas as pd
 
 import msaf
 from msaf import input_output as io

--- a/msaf/__init__.py
+++ b/msaf/__init__.py
@@ -1,6 +1,7 @@
 """Top-level module for MSAF."""
-from .version import version as __version__
 import numpy as np
+
+from .version import version as __version__
 
 __author__ = "Oriol Nieto"
 __copyright__ = "Copyright 2016, Music and Audio Research Lab (MARL)"
@@ -17,17 +18,12 @@ MSAFRC_WIN_FILE = "~/.msafrc.txt"
 from msaf.configdefaults import config
 
 # Import all submodules
-from . import features
+from . import algorithms, eval, features
 from . import input_output as io
-from . import eval
-from . import plotting
-from . import utils
-from . import algorithms
-from . import run
+from . import plotting, run, utils
 from .base import features_registry
+from .input_output import get_all_boundary_algorithms, get_all_label_algorithms
 from .run import process
-from .input_output import get_all_boundary_algorithms
-from .input_output import get_all_label_algorithms
 
 # TODO: Include this in algorithms
 feat_dict = {

--- a/msaf/algorithms/cnmf/segmenter.py
+++ b/msaf/algorithms/cnmf/segmenter.py
@@ -2,8 +2,8 @@ import numpy as np
 from scipy import ndimage
 
 import msaf.utils as U
-from msaf.algorithms.interface import SegmenterInterface
 from msaf import pymf
+from msaf.algorithms.interface import SegmenterInterface
 
 
 def median_filter(X, M=8):

--- a/msaf/algorithms/example/segmenter.py
+++ b/msaf/algorithms/example/segmenter.py
@@ -1,6 +1,7 @@
 """Example of algorithm for MSAF."""
-from msaf.algorithms.interface import SegmenterInterface
 import numpy as np
+
+from msaf.algorithms.interface import SegmenterInterface
 
 
 class Segmenter(SegmenterInterface):

--- a/msaf/algorithms/fmc2d/segmenter.py
+++ b/msaf/algorithms/fmc2d/segmenter.py
@@ -1,15 +1,15 @@
 import logging
+
 import numpy as np
 import scipy.cluster.vq as vq
 from sklearn import mixture
 from sklearn.cluster import KMeans
 
+import msaf.utils as U
+from msaf.algorithms.interface import SegmenterInterface
 
 from . import utils_2dfmc as utils2d
 from .xmeans import XMeans
-
-import msaf.utils as U
-from msaf.algorithms.interface import SegmenterInterface
 
 
 def get_feat_segments(F, bound_idxs):

--- a/msaf/algorithms/fmc2d/segmenter.py
+++ b/msaf/algorithms/fmc2d/segmenter.py
@@ -4,7 +4,7 @@ import scipy.cluster.vq as vq
 from sklearn import mixture
 from sklearn.cluster import KMeans
 
-# Local stuff
+
 from . import utils_2dfmc as utils2d
 from .xmeans import XMeans
 

--- a/msaf/algorithms/fmc2d/segmenter.py
+++ b/msaf/algorithms/fmc2d/segmenter.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 import logging
 import numpy as np
 import scipy.cluster.vq as vq

--- a/msaf/algorithms/fmc2d/utils_2dfmc.py
+++ b/msaf/algorithms/fmc2d/utils_2dfmc.py
@@ -1,9 +1,11 @@
 """Set of util functions for the section similarity project."""
 
 import copy
-import numpy as np
 import json
+
+import numpy as np
 import scipy.fftpack
+
 
 def resample_mx(X, incolpos, outcolpos):
     """

--- a/msaf/algorithms/fmc2d/xmeans.py
+++ b/msaf/algorithms/fmc2d/xmeans.py
@@ -2,8 +2,9 @@
 """Class that implements X-means."""
 
 import argparse
-import numpy as np
 import time
+
+import numpy as np
 import pylab as plt
 import scipy.cluster.vq as vq
 from scipy.spatial import distance

--- a/msaf/algorithms/foote/segmenter.py
+++ b/msaf/algorithms/foote/segmenter.py
@@ -1,6 +1,6 @@
 import numpy as np
+from scipy import ndimage, signal
 from scipy.spatial import distance
-from scipy import signal, ndimage
 
 import msaf
 from msaf.algorithms.interface import SegmenterInterface

--- a/msaf/algorithms/foote/segmenter.py
+++ b/msaf/algorithms/foote/segmenter.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 import numpy as np
 from scipy.spatial import distance
 from scipy import signal, ndimage

--- a/msaf/algorithms/interface.py
+++ b/msaf/algorithms/interface.py
@@ -1,5 +1,6 @@
 """Interface for all the algorithms in MSAF."""
 import numpy as np
+
 import msaf.utils as U
 
 

--- a/msaf/algorithms/olda/OLDA.py
+++ b/msaf/algorithms/olda/OLDA.py
@@ -3,9 +3,11 @@
 # Ordinal LDA
 
 import itertools
+
 import numpy as np
 import scipy.linalg
 from sklearn.base import BaseEstimator, TransformerMixin
+
 
 class OLDA(BaseEstimator, TransformerMixin):
 

--- a/msaf/algorithms/olda/fit_olda_model.py
+++ b/msaf/algorithms/olda/fit_olda_model.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
-import numpy as np
+import sys
 
-import mir_eval
-import jams
 import cPickle as pickle
-
+import jams
+import mir_eval
+import numpy as np
 import OLDA
 import segmenter
 

--- a/msaf/algorithms/olda/make_train.py
+++ b/msaf/algorithms/olda/make_train.py
@@ -1,18 +1,17 @@
 #!/usr/bin/env python
 
 import argparse
-import numpy as np
-import librosa
 import os
 import time
 
-from joblib import Parallel, delayed
 import cPickle as pickle
+import librosa
+import numpy as np
+from joblib import Parallel, delayed
+from segmenter import features
 
 import msaf
 from msaf.base import Features
-
-from segmenter import features
 
 
 def align_segmentation(beat_times, song):

--- a/msaf/algorithms/olda/segmenter.py
+++ b/msaf/algorithms/olda/segmenter.py
@@ -4,13 +4,12 @@ import argparse
 import logging
 import sys
 
-import numpy as np
-import scipy.signal
-import scipy.linalg
-
 import librosa
-import msaf
+import numpy as np
+import scipy.linalg
+import scipy.signal
 
+import msaf
 from msaf.algorithms.interface import SegmenterInterface
 from msaf.base import Features
 

--- a/msaf/algorithms/olda/segmenter.py
+++ b/msaf/algorithms/olda/segmenter.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # CREATED:2013-08-22 12:20:01 by Brian McFee <brm2132@columbia.edu>
 """Music segmentation using timbre, pitch, repetition and time."""
 import argparse

--- a/msaf/algorithms/scluster/main2.py
+++ b/msaf/algorithms/scluster/main2.py
@@ -4,12 +4,11 @@
 # License: ISC
 
 from collections import defaultdict
-import numpy as np
-import scipy
-
-import sklearn.cluster
 
 import librosa
+import numpy as np
+import scipy
+import sklearn.cluster
 
 
 def embed_beats(A_rep, A_loc, config):

--- a/msaf/algorithms/scluster/segmenter.py
+++ b/msaf/algorithms/scluster/segmenter.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 import numpy as np
 
 from msaf.algorithms.interface import SegmenterInterface

--- a/msaf/algorithms/scluster/segmenter.py
+++ b/msaf/algorithms/scluster/segmenter.py
@@ -2,6 +2,7 @@ import numpy as np
 
 from msaf.algorithms.interface import SegmenterInterface
 from msaf.base import Features
+
 from . import main2
 
 

--- a/msaf/algorithms/sf/segmenter.py
+++ b/msaf/algorithms/sf/segmenter.py
@@ -1,10 +1,10 @@
 import librosa
 import numpy as np
+from scipy import ndimage, signal
 from scipy.spatial import distance
-from scipy import signal, ndimage
 
-from msaf.algorithms.interface import SegmenterInterface
 import msaf.utils as U
+from msaf.algorithms.interface import SegmenterInterface
 
 
 def median_filter(X, M=8):

--- a/msaf/algorithms/sf/segmenter.py
+++ b/msaf/algorithms/sf/segmenter.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 import librosa
 import numpy as np
 from scipy.spatial import distance

--- a/msaf/algorithms/vmo/__init__.py
+++ b/msaf/algorithms/vmo/__init__.py
@@ -7,5 +7,5 @@ Variable Markov Oracle
     Segmenter
 """
 from .config import *
-from .segmenter import *
 from .main import *
+from .segmenter import *

--- a/msaf/algorithms/vmo/main.py
+++ b/msaf/algorithms/vmo/main.py
@@ -1,10 +1,10 @@
-import sklearn
+import librosa
 import numpy as np
-import vmo
-import vmo.analysis as van
 import scipy.linalg
 import scipy.ndimage
-import librosa
+import sklearn
+import vmo
+import vmo.analysis as van
 
 
 def vmo_routine(feature):

--- a/msaf/algorithms/vmo/segmenter.py
+++ b/msaf/algorithms/vmo/segmenter.py
@@ -1,6 +1,8 @@
 """Variable Markov Oracle algorithm."""
-from msaf.algorithms.interface import SegmenterInterface
 import librosa
+
+from msaf.algorithms.interface import SegmenterInterface
+
 from . import main
 
 

--- a/msaf/base.py
+++ b/msaf/base.py
@@ -6,18 +6,19 @@ included here.
 
 import collections
 import datetime
-from enum import Enum
-import librosa
-import logging
-import jams
 import json
-import numpy as np
+import logging
 import os
+from enum import Enum
 
+import jams
+import librosa
+import numpy as np
 
 import msaf
-from msaf.exceptions import WrongFeaturesFormatError, NoFeaturesFileError,\
-    FeaturesNotFound, FeatureTypeNotFound, FeatureParamsError, NoAudioFileError
+from msaf.exceptions import (FeatureParamsError, FeaturesNotFound,
+                             FeatureTypeNotFound, NoAudioFileError,
+                             NoFeaturesFileError, WrongFeaturesFormatError)
 
 # Three types of features at the moment:
 #   - framesync: Frame-wise synchronous.

--- a/msaf/base.py
+++ b/msaf/base.py
@@ -14,7 +14,7 @@ import json
 import numpy as np
 import os
 
-# Local stuff
+
 import msaf
 from msaf.exceptions import WrongFeaturesFormatError, NoFeaturesFileError,\
     FeaturesNotFound, FeatureTypeNotFound, FeatureParamsError, NoAudioFileError

--- a/msaf/configdefaults.py
+++ b/msaf/configdefaults.py
@@ -1,11 +1,10 @@
 """Default configuration parameters for MSAF."""
 import logging
+
 import numpy as np
 
-from msaf.configparser import \
-    (AddConfigVar, EnumStr, FloatParam,
-     IntParam, StrParam, ListParam, MsafConfigParser)
-
+from msaf.configparser import (AddConfigVar, EnumStr, FloatParam, IntParam,
+                               ListParam, MsafConfigParser, StrParam)
 
 _logger = logging.getLogger('msaf.configdefaults')
 

--- a/msaf/configparser.py
+++ b/msaf/configparser.py
@@ -5,19 +5,19 @@ theano.
 """
 
 try:
-    from configparser import (ConfigParser, NoOptionError, NoSectionError,
-                              InterpolationError)
+    from configparser import (ConfigParser, InterpolationError, NoOptionError,
+                              NoSectionError)
 except ImportError:
     from configparser import (ConfigParser, NoOptionError, NoSectionError,
                                         InterpolationError)
+
 import os
 import shlex
-from io import StringIO
 import sys
 import warnings
+from io import StringIO
 
 import msaf
-
 
 MSAF_FLAGS = os.getenv(msaf.MSAF_FLAGS_VAR, "")
 # The MSAF_FLAGS environment variable should be a list of comma-separated

--- a/msaf/eval.py
+++ b/msaf/eval.py
@@ -14,7 +14,7 @@ import numpy as np
 import os
 import pandas as pd
 
-# Local stuff
+
 import msaf
 from msaf.exceptions import NoReferencesError
 import msaf.input_output as io

--- a/msaf/eval.py
+++ b/msaf/eval.py
@@ -6,19 +6,19 @@ ground truth (human annotated data).
 
     process
 """
-import jams
-from joblib import Parallel, delayed
 import logging
+import os
+
+import jams
 import mir_eval
 import numpy as np
-import os
 import pandas as pd
-
+from joblib import Parallel, delayed
 
 import msaf
-from msaf.exceptions import NoReferencesError
 import msaf.input_output as io
 from msaf import utils
+from msaf.exceptions import NoReferencesError
 
 
 def print_results(results):

--- a/msaf/features.py
+++ b/msaf/features.py
@@ -17,7 +17,6 @@ Here is a list of all the available features:
 import librosa
 import numpy as np
 
-
 from msaf import config
 from msaf.base import Features
 from msaf.exceptions import FeatureParamsError

--- a/msaf/features.py
+++ b/msaf/features.py
@@ -17,7 +17,7 @@ Here is a list of all the available features:
 import librosa
 import numpy as np
 
-# Local stuff
+
 from msaf import config
 from msaf.base import Features
 from msaf.exceptions import FeatureParamsError

--- a/msaf/input_output.py
+++ b/msaf/input_output.py
@@ -11,7 +11,7 @@ from collections import defaultdict
 import jams
 import numpy as np
 
-# Local stuff
+
 import msaf
 from msaf import utils
 from msaf.exceptions import NoEstimationsError

--- a/msaf/input_output.py
+++ b/msaf/input_output.py
@@ -11,7 +11,6 @@ from collections import defaultdict
 import jams
 import numpy as np
 
-
 import msaf
 from msaf import utils
 from msaf.exceptions import NoEstimationsError

--- a/msaf/plotting.py
+++ b/msaf/plotting.py
@@ -1,15 +1,14 @@
 """This script contains methods to plot multiple aspects of the results of
 MSAF."""
 
-import jams
 import logging
-import mir_eval
-import numpy as np
 import os
 
+import jams
+import mir_eval
+import numpy as np
 
-from msaf import io
-from msaf import utils
+from msaf import io, utils
 
 translate_ids = {
     "2dfmc": "2D-FMC",
@@ -147,6 +146,7 @@ def plot_one_track(file_struct, est_times, est_labels, boundaries_id, labels_id,
                    title=None):
     """Plots the results of one track, with ground truth if it exists."""
     import matplotlib.pyplot as plt
+
     # Set up the boundaries id
     bid_lid = boundaries_id
     if labels_id is not None:

--- a/msaf/plotting.py
+++ b/msaf/plotting.py
@@ -7,7 +7,7 @@ import mir_eval
 import numpy as np
 import os
 
-# Local stuff
+
 from msaf import io
 from msaf import utils
 

--- a/msaf/pymf/__init__.py
+++ b/msaf/pymf/__init__.py
@@ -14,31 +14,25 @@ GNU General Public License (GPL)
 import numpy as np
 from scipy.sparse import issparse
 
+from .aa import *
+from .bnmf import *
+from .chnmf import *
+from .cmd import *
+from .cmeans import *
+from .cnmf import *
+from .cur import *
+from .gmap import *
+from .kmeans import *
+from .laesa import *
 from .nmf import *
 from .nmfals import *
 from .nmfnnls import *
-from .cnmf import *
-from .chnmf import *
-from .snmf import *
-from .aa import *
-
-from .laesa import *
-from .bnmf import *
-
-from .sub import *
-
-from .svd import *
 from .pca import *
-from .cur import *
-from .sivm_cur import *
-from .cmd import *
-
-from .kmeans import *
-from .cmeans import *
-
 from .sivm import *
-from .sivm_sgreedy import *
-from .sivm_search import *
+from .sivm_cur import *
 from .sivm_gsat import *
-
-from .gmap import *
+from .sivm_search import *
+from .sivm_sgreedy import *
+from .snmf import *
+from .sub import *
+from .svd import *

--- a/msaf/pymf/aa.py
+++ b/msaf/pymf/aa.py
@@ -13,10 +13,10 @@
 
 
 import numpy as np
-from cvxopt import solvers, base
+from cvxopt import base, solvers
 
-from .svd import pinv
 from .nmf import NMF
+from .svd import pinv
 
 __all__ = ["AA"]
 

--- a/msaf/pymf/bnmf.py
+++ b/msaf/pymf/bnmf.py
@@ -13,6 +13,7 @@ Applications. ICDM 2007
 
 
 import numpy as np
+
 from .nmf import NMF
 
 __all__ = ["BNMF"]

--- a/msaf/pymf/chnmf.py
+++ b/msaf/pymf/chnmf.py
@@ -13,12 +13,13 @@ Factorization in the Wild. ICDM 2009.
 """
 
 
+from itertools import combinations
+
 import numpy as np
 
-from itertools import combinations
+from .aa import AA
 from .dist import vq
 from .pca import PCA
-from .aa import AA
 
 __all__ = ["CHNMF"]
 

--- a/msaf/pymf/cmd.py
+++ b/msaf/pymf/cmd.py
@@ -13,6 +13,7 @@ Sparse Graphs, in Proc. SIAM Int. Conf. on Data Mining.
 
 
 import numpy as np
+
 from .cur import CUR
 
 __all__ = ["CMD"]

--- a/msaf/pymf/cnmf.py
+++ b/msaf/pymf/cnmf.py
@@ -12,11 +12,12 @@ IEEE Trans. on Pattern Analysis and Machine Intelligence 32(1), 45-55.
 """
 
 
-import numpy as np
 import logging
-from .nmf import NMF
-from .kmeans import Kmeans
 
+import numpy as np
+
+from .kmeans import Kmeans
+from .nmf import NMF
 
 __all__ = ["CNMF"]
 

--- a/msaf/pymf/cur.py
+++ b/msaf/pymf/cur.py
@@ -15,8 +15,7 @@ a Compressed Approixmate Matrix Decomposition', SIAM J. Computing 36(1), 184-206
 import numpy as np
 import scipy.sparse
 
-from .svd import pinv, SVD
-
+from .svd import SVD, pinv
 
 __all__ = ["CUR"]
 

--- a/msaf/pymf/cursl.py
+++ b/msaf/pymf/cursl.py
@@ -13,11 +13,11 @@ a Compressed Approixmate Matrix Decomposition', SIAM J. Computing 36(1), 184-206
 """
 
 
+from cmd import CMD
+
 import numpy as np
 import scipy.sparse
-
 from svd import SVD
-from cmd import CMD
 
 __all__ = ["CURSL"]
 

--- a/msaf/pymf/gmap.py
+++ b/msaf/pymf/gmap.py
@@ -9,11 +9,11 @@ GMAP: Class for Geometric-Map
 """
 
 
-import scipy.sparse
 import numpy as np
+import scipy.sparse
 
-from .dist import *
 from .aa import AA
+from .dist import *
 from .kmeans import Kmeans
 
 __all__ = ["GMAP"]

--- a/msaf/pymf/greedy.py
+++ b/msaf/pymf/greedy.py
@@ -15,10 +15,11 @@ Reconstruction via Greedy Approximation of SVD. ISAAC'2008.
 
 
 import time
-import scipy.sparse
+
 import numpy as np
-from svd import *
+import scipy.sparse
 from nmf import NMF
+from svd import *
 
 __all__ = ["GREEDY"]
 

--- a/msaf/pymf/greedycur.py
+++ b/msaf/pymf/greedycur.py
@@ -17,8 +17,8 @@ Reconstruction via Greedy Approximation of SVD. ISAAC'2008.
 
 
 import numpy as np
-from greedy import GREEDY
 from cur import CUR
+from greedy import GREEDY
 
 __all__ = ["GREEDYCUR"]
 

--- a/msaf/pymf/kmeans.py
+++ b/msaf/pymf/kmeans.py
@@ -6,8 +6,9 @@
 """PyMF K-means clustering (unary-convex matrix factorization)."""
 
 
-import numpy as np
 import random
+
+import numpy as np
 
 from . import dist
 from .nmf import NMF

--- a/msaf/pymf/nmf.py
+++ b/msaf/pymf/nmf.py
@@ -12,9 +12,10 @@ Matrix Factorization, Nature 401(6755), 788-799.
 """
 
 
-import numpy as np
 import logging
 import logging.config
+
+import numpy as np
 import scipy.sparse
 
 __all__ = ["NMF"]

--- a/msaf/pymf/nmfals.py
+++ b/msaf/pymf/nmfals.py
@@ -15,7 +15,8 @@ Matrix Factorization, Nature 401(6755), 788-799.
 
 
 import numpy as np
-from cvxopt import solvers, base
+from cvxopt import base, solvers
+
 from .nmf import NMF
 
 __all__ = ["NMFALS"]

--- a/msaf/pymf/nmfnnls.py
+++ b/msaf/pymf/nmfnnls.py
@@ -15,6 +15,7 @@ Matrix Factorization, Nature 401(6755), 788-799.
 
 
 import scipy.optimize
+
 from .nmf import NMF
 
 __all__ = ["NMFNNLS"]

--- a/msaf/pymf/nndsvd.py
+++ b/msaf/pymf/nndsvd.py
@@ -14,7 +14,6 @@ start for nonnegative matrix factorization, Pattern Recognition, 41, 1350-1362
 
 
 import numpy as np
-
 from nmf import NMF
 from svd import SVD
 

--- a/msaf/pymf/pca.py
+++ b/msaf/pymf/pca.py
@@ -15,7 +15,6 @@ import numpy as np
 from .nmf import NMF
 from .svd import SVD
 
-
 __all__ = ["PCA"]
 
 class PCA(NMF):

--- a/msaf/pymf/rnmf.py
+++ b/msaf/pymf/rnmf.py
@@ -13,7 +13,6 @@ Matrix Factorization, Nature 401(6755), 788-799.
 
 
 import numpy as np
-
 from nmf import NMF
 
 __all__ = ["RNMF"]

--- a/msaf/pymf/sivm.py
+++ b/msaf/pymf/sivm.py
@@ -13,11 +13,11 @@ Conf. on Information and Knowledge Management. ACM. 2010.
 """
 
 
-import scipy.sparse
 import numpy as np
+import scipy.sparse
 
-from .dist import *
 from .aa import AA
+from .dist import *
 
 __all__ = ["SIVM"]
 

--- a/msaf/pymf/sivm_cur.py
+++ b/msaf/pymf/sivm_cur.py
@@ -14,8 +14,9 @@ Conf. on Information and Knowledge Management. ACM. 2010.
 
 
 import numpy as np
-from .sivm import SIVM
+
 from .cur import CUR
+from .sivm import SIVM
 
 __all__ = ["SIVM_CUR"]
 

--- a/msaf/pymf/sivm_gsat.py
+++ b/msaf/pymf/sivm_gsat.py
@@ -14,10 +14,12 @@ Conf. on Information and Knowledge Management. ACM. 2010.
 
 
 import logging
+
 import numpy as np
+
 from .dist import *
-from .vol import cmdet
 from .sivm import SIVM
+from .vol import cmdet
 
 __all__ = ["SIVM_GSAT"]
 

--- a/msaf/pymf/sivm_search.py
+++ b/msaf/pymf/sivm_search.py
@@ -14,14 +14,15 @@ Conf. on Information and Knowledge Management. ACM. 2010.
 
 
 import numpy as np
+
 try:
     from scipy.misc import factorial
 except:
     from scipy.special import factorial # scipy > 1.3
 
 from .dist import *
-from .vol import *
 from .sivm import SIVM
+from .vol import *
 
 __all__ = ["SIVM_SEARCH"]
 

--- a/msaf/pymf/sivm_sgreedy.py
+++ b/msaf/pymf/sivm_sgreedy.py
@@ -13,12 +13,13 @@ Conf. on Information and Knowledge Management. ACM. 2010.
 """
 
 
-import numpy as np
 import time
 
+import numpy as np
+
 from .dist import *
-from .vol import *
 from .sivm_search import SIVM_SEARCH
+from .vol import *
 
 __all__ = ["SIVM_SGREEDY"]
 

--- a/msaf/pymf/sub.py
+++ b/msaf/pymf/sub.py
@@ -13,17 +13,17 @@ Copyright (C) Christian Thurau, 2010. GNU General Public License (GPL).
 
 
 
-import numpy as np
 import random
-#from itertools import combinations
-from .chnmf import combinations
+
+import numpy as np
 
 from . import dist
-from .chnmf import quickhull
-from .nmf import NMF
-from .pca import PCA
+#from itertools import combinations
+from .chnmf import combinations, quickhull
 from .kmeans import Kmeans
 from .laesa import LAESA
+from .nmf import NMF
+from .pca import PCA
 from .sivm import SIVM
 
 __all__ = ["SUB"]

--- a/msaf/pymf/svd.py
+++ b/msaf/pymf/svd.py
@@ -11,16 +11,16 @@ pinv() : Compute the pseudoinverse of a Matrix
 
 
 
-from numpy.linalg import eigh
 import scipy.sparse
+from numpy.linalg import eigh
 
 try:
     import scipy.sparse.linalg.eigen.arpack as linalg
 except (ImportError, AttributeError):
     import scipy.sparse.linalg as linalg
 
-
 import numpy as np
+
 
 def pinv(A, k=-1, eps=10**-8):    
     # Compute Pseudoinverse of a matrix

--- a/msaf/pymf/vol.py
+++ b/msaf/pymf/vol.py
@@ -11,10 +11,11 @@ simplex_volume(): Ordinary simplex volume
 
 
 import numpy as np
+
 try:
 	from scipy.misc import factorial
 except:
-	from scipy.special import factorial # scipy > 1.3
+	from scipy.special import factorial  # scipy > 1.3
 
 __all__ = ["cmdet", "simplex"]
 

--- a/msaf/run.py
+++ b/msaf/run.py
@@ -1,18 +1,18 @@
 """This module contains multiple functions in order to run MSAF algorithms."""
-from copy import deepcopy
-from joblib import Parallel, delayed
-import librosa
 import logging
-import numpy as np
 import os
+from copy import deepcopy
+
+import librosa
+import numpy as np
+from joblib import Parallel, delayed
 
 import msaf
-from msaf import input_output as io
-from msaf import utils
-from msaf import plotting
-from msaf.features import Features
-from msaf.exceptions import NoHierBoundaryError, NoAudioFileError
 import msaf.algorithms as algorithms
+from msaf import input_output as io
+from msaf import plotting, utils
+from msaf.exceptions import NoAudioFileError, NoHierBoundaryError
+from msaf.features import Features
 
 
 def get_boundaries_module(boundaries_id):

--- a/msaf/utils.py
+++ b/msaf/utils.py
@@ -1,8 +1,9 @@
 """Useful functions that are common in MSAF."""
+import os
+
 import librosa
 import mir_eval
 import numpy as np
-import os
 import scipy.io.wavfile
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
-from setuptools import setup, find_packages
 import glob
 import imp
+
+from setuptools import find_packages, setup
 
 version = imp.load_source('msaf.version', 'msaf/version.py')
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -9,7 +9,8 @@ from pytest import raises
 # Msaf imports
 import msaf
 from msaf.base import FeatureTypes
-from msaf.exceptions import FeatureParamsError, FeatureTypeNotFound, NoAudioFileError
+from msaf.exceptions import (FeatureParamsError, FeatureTypeNotFound,
+                             NoAudioFileError)
 from msaf.features import CQT, MFCC, PCP, Features, Tempogram, Tonnetz
 from msaf.input_output import FileStruct
 


### PR DESCRIPTION
Very minor style change (so just close this if not interesting) but a common convention is to group imports by standard library, third-party and first-party. `isort` is convenient for automatically doing that. I've run that across the repo in this PR.