### PR TITLE
Adding the Mel and Log Mel spectrograms.

### DIFF
--- a/msaf/__init__.py
+++ b/msaf/__init__.py
@@ -34,5 +34,5 @@ feat_dict = {
     'olda': '',
     'cnmf': 'pcp',
     '2dfmc': '',
-    'cbm': 'pcp',
+    'cbm': 'log_mel',
 }

--- a/msaf/__init__.py
+++ b/msaf/__init__.py
@@ -34,5 +34,5 @@ feat_dict = {
     'olda': '',
     'cnmf': 'pcp',
     '2dfmc': '',
-    'cbm': 'log_mel',
+    'cbm': 'pcp',
 }

--- a/msaf/configdefaults.py
+++ b/msaf/configdefaults.py
@@ -66,6 +66,18 @@ AddConfigVar('cqt.ref_power',
              "Reference function to use for the logarithm power.",
              EnumStr("max", "min", "median"))
 
+# Mel Features
+## Mel spectrograms are defined following [1]
+## [1] Ullrich, K., Schl\"uter, J., & Grill, T. (2014, October). Boundary Detection in Music Structure Analysis using Convolutional Neural Networks. In ISMIR (pp. 417-422). 
+AddConfigVar('mel.n_mels', "Number of mel bins.",
+             IntParam(80))
+AddConfigVar('mel.f_min',
+             "Minimum frequency for constructing the mel scale.",
+             FloatParam(80.0))
+AddConfigVar('mel.f_max',
+             "Maximum frequency for constructing the mel scale.",
+             FloatParam(16000))
+
 # MFCC Features
 AddConfigVar('mfcc.n_mels', "Number of mel filters.", IntParam(128))
 AddConfigVar('mfcc.n_mfcc', "Number of mel coefficients.", IntParam(14))

--- a/msaf/features.py
+++ b/msaf/features.py
@@ -200,11 +200,8 @@ class LogMel(Features):
         # Init the parent
         super().__init__(file_struct=file_struct, sr=sr, hop_length=hop_length,
                          feat_type=feat_type)
-        self.n_fft = n_fft
-        # Init the Mel parameters
-        self.n_mels = n_mels
-        self.f_min = f_min
-        self.f_max = f_max
+        self.mel = Mel(self.file_struct, self.feat_type, self.sr,self.hop_length, 
+                       n_fft,n_mels, f_min, f_max).features
 
     @classmethod
     def get_id(cls):
@@ -220,11 +217,7 @@ class LogMel(Features):
             The features, each row representing a feature vector for a give
             time frame/beat.
         """
-        mel = Mel(self.file_struct, self.feat_type, self.sr,
-                 self.hop_length, self.n_fft,
-                 self.n_mels, self.f_min, 
-                 self.f_max).features
-        return librosa.power_to_db(mel)
+        return librosa.power_to_db(self.mel)
 
 class MFCC(Features):
     """This class contains the implementation of the MFCC Features.

--- a/msaf/features.py
+++ b/msaf/features.py
@@ -7,6 +7,8 @@ Here is a list of all the available features:
     :toctree: generated/
 
     CQT
+    Mel
+    LogMel
     MFCC
     PCP
     Tonnetz
@@ -92,6 +94,137 @@ class CQT(Features):
         cqt = librosa.amplitude_to_db(linear_cqt, ref=self.ref_power).T
         return cqt
 
+class Mel(Features):
+    """This class contains the implementation of the Mel Spectrogram.
+
+    The Mel spectrogram contains the frequency content of a given audio signal.
+
+    The frequency content is expressed according to the Mel scale,
+    which is a perceptually-motivated scale of frequencies.
+
+    See https://en.wikipedia.org/wiki/Mel_scale for more details.
+    """
+    def __init__(self, file_struct, feat_type, sr=config.sample_rate,
+                 hop_length=config.hop_size, n_fft=config.n_fft,
+                 n_mels=config.mel.n_mels, f_min=config.mel.f_min, 
+                 f_max=config.mel.f_max):
+        """Constructor of the class.
+
+        Parameters
+        ----------
+        file_struct: `msaf.input_output.FileStruct`
+            Object containing the file paths from where to extract/read
+            the features.
+        feat_type: `FeatureTypes`
+            Enum containing the type of features.
+        sr: int > 0
+            Sampling rate for the analysis.
+        hop_length: int > 0
+            Hop size in frames for the analysis.
+        n_fft: int > 0
+            Number of samples in the Fourier window.
+        n_mels: int > 0
+            Number of mel bins in the scale.
+        f_min: float > 0
+            Minimum frequency.
+        f_min: int > 0
+            Maximal frequency.
+        """
+        # Init the parent
+        super().__init__(file_struct=file_struct, sr=sr, hop_length=hop_length,
+                         feat_type=feat_type)
+        self.n_fft = n_fft
+        # Init the Mel parameters
+        self.n_mels = n_mels
+        self.f_min = f_min
+        self.f_max = f_max
+
+    @classmethod
+    def get_id(cls):
+        """Identifier of these features."""
+        return "mel"
+
+    def compute_features(self):
+        """Actual implementation of the features.
+
+        Returns
+        -------
+        mel: np.array(N, F)
+            The features, each row representing a feature vector for a give
+            time frame/beat.
+        """
+        mel = librosa.feature.melspectrogram(y=self._audio, 
+                                             sr = self.sr, 
+                                             n_fft=self.n_fft,
+                                             hop_length = self.hop_length, 
+                                             n_mels=self.n_mels, 
+                                             fmin=self.f_min,
+                                             fmax=self.f_max)
+        module_mel = np.abs(mel).T
+        return module_mel
+
+class LogMel(Features):
+    """This class contains the implementation of the Log Mel Spectrogram.
+
+    The Log Mel spectrogram contains the logarithmic frequency content
+    of a given audio signal.
+
+    This is exactly the logarithm of the Mel spectrogram.
+    """
+    def __init__(self, file_struct, feat_type, sr=config.sample_rate,
+                 hop_length=config.hop_size, n_fft=config.n_fft,
+                 n_mels=config.mel.n_mels, f_min=config.mel.f_min, 
+                 f_max=config.mel.f_max):
+        """Constructor of the class.
+
+        Parameters
+        ----------
+        file_struct: `msaf.input_output.FileStruct`
+            Object containing the file paths from where to extract/read
+            the features.
+        feat_type: `FeatureTypes`
+            Enum containing the type of features.
+        sr: int > 0
+            Sampling rate for the analysis.
+        hop_length: int > 0
+            Hop size in frames for the analysis.
+        n_fft: int > 0
+            Number of samples in the Fourier window.
+        n_mels: int > 0
+            Number of mel bins in the scale.
+        f_min: float > 0
+            Minimum frequency.
+        f_min: int > 0
+            Maximal frequency.
+        """
+        # Init the parent
+        super().__init__(file_struct=file_struct, sr=sr, hop_length=hop_length,
+                         feat_type=feat_type)
+        self.n_fft = n_fft
+        # Init the Mel parameters
+        self.n_mels = n_mels
+        self.f_min = f_min
+        self.f_max = f_max
+
+    @classmethod
+    def get_id(cls):
+        """Identifier of these features."""
+        return "log_mel"
+
+    def compute_features(self):
+        """Actual implementation of the features.
+
+        Returns
+        -------
+        mel: np.array(N, F)
+            The features, each row representing a feature vector for a give
+            time frame/beat.
+        """
+        mel = Mel(self.file_struct, self.feat_type, self.sr,
+                 self.hop_length, self.n_fft,
+                 self.n_mels, self.f_min, 
+                 self.f_max).features
+        return librosa.power_to_db(mel)
 
 class MFCC(Features):
     """This class contains the implementation of the MFCC Features.

--- a/msaf/features.py
+++ b/msaf/features.py
@@ -200,8 +200,13 @@ class LogMel(Features):
         # Init the parent
         super().__init__(file_struct=file_struct, sr=sr, hop_length=hop_length,
                          feat_type=feat_type)
+        self.n_fft = n_fft
+        # Init the Mel parameters
+        self.n_mels = n_mels
+        self.f_min = f_min
+        self.f_max = f_max
         self.mel = Mel(self.file_struct, self.feat_type, self.sr,self.hop_length, 
-                       n_fft,n_mels, f_min, f_max).features
+                       self.n_fft,self.n_mels, self.f_min, self.f_max).features
 
     @classmethod
     def get_id(cls):


### PR DESCRIPTION
Hi! And Happy New Year!
This pull request aims at implementing two additional features: the Mel and the Log Mel spectrograms.
The Mel filter bank is defined following [1] (i.e. 80 mel coefficients, with a min frequency of 80Hz, and a max frequency of 16kHz.
Note that these Mel spectrograms were developed for signals sampled at 44.1kHZ with 2048 samples per window, while, in the current implementation of MSAF, signals are sampled at 22.05kHz with 4096 frames per window. It should be discussed how to solve that ambiguity (divide by two the max frequency? Change the sampling rate for Mel spectrograms?).
Let me know if I can improve the code in any way!

References
[1] Ullrich, K., Schlüter, J., & Grill, T. (2014, October). Boundary Detection in Music Structure Analysis using Convolutional Neural Networks. In ISMIR (pp. 417-422). 