### PR TITLE
Beatwise TF matrix (or multibeat)

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -124,6 +124,13 @@ import MSAF and print the config variable, as in:
     The size of the hop size, which should be smaller than the ``n_fft`` value,
     such that overlap is allowed.
 
+.. attribute:: frames_per_beat
+
+    Positive int value, default: 3
+
+    The number of frames kept per beat when using the multibeat features.
+    Must be lower than the number of computed between two beats.
+
 .. attribute:: features_tmp_file
 
     String value, default ``'.features_msaf_tmp.json'``

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -24,7 +24,8 @@ The format of the ``json`` file is as follows:
             "audio_file": "<path to audio file>",
             "dur": "<duration of audio>",
             "sample_rate": "<sample rate>",
-            "hop_length": "<hop lenght>"
+            "hop_length": "<hop lenght>",
+            "frames_per_beat": "<frames per beat>"
         },
         "metadata": {
             "timestamp": "<YYYY/MM/DD hh:mm:ss>",
@@ -47,6 +48,14 @@ The format of the ``json`` file is as follows:
                 [ 0.0, 0.0, "..." ],
                 "..."
             ],
+            "est_multibeat": [
+                [0.0, 0.0, "..."],
+                "..."
+            ],
+             "ann_multibeat": [
+                [0.0, 0.0, "..."],
+                "..."
+            ],
             "params": {
                 "<param_name1>": "<param_value2>",
                 "<param_name1>": "<param_value2>",
@@ -55,6 +64,8 @@ The format of the ``json`` file is as follows:
         }
         "est_beatsync_times": [ 0.0, 1.0, "..." ],
         "ann_beatsync_times": [ 0.0, 1.0, "..." ],
+        "est_multibeat_times": [ 0.0, 1.0, "..." ],
+        "ann_multibeat_times": [ 0.0, 1.0, "..." ],
         "est_beats": [ 0.0, 1.0, "..." ],
         "ann_beats": [ 0.0, 1.0, "..." ]
     }
@@ -67,11 +78,16 @@ A brief description for the main keys of this ``json`` file follows:
 * ``ann_beats``: contains the set of reference beats, in seconds (only exists if reference beats are available).
 * ``est_beatsync_times``: contains the set times associated with each (estimated-)beat-synchronous feature (might differ with `est_beats` in the beginning or end).
 * ``ann_beatsync_times``: contains the set times associated with each (annotated-)beat-synchronous feature (might differ with `ann_beats` in the beginning or end).
+* ``est_beatsync_times``: contains the set times associated with each (estimated-)beat-synchronous feature when using multibeat(might differ with `est_beatsync_times` in the end).
+* ``ann_beatsync_times``: contains the set times associated with each (annotated-)beat-synchronous feature when using multibeat(might differ with `ann_beatsync_times` in the r end).
+
 * ``<feature_id>`` (e.g., ``pcp``, ``mfcc``): contains the actual features of the given audio file. Inside this key the following sub-keys can be found:
 
     * ``framesync``: Actual frame-wise features.
     * ``est_beatsync``: Features synchronized to the estimated beats.
     * ``ann_beatsync``: Features synchronized to the reference beats (only exists if reference beats are available).
+    * ``est_multibeat``: Features synchronized to the estimated beats (`frames_per_beat` frames are computed for each beat).
+    * ``ann_multibeat``: Features synchronized to the reference beats (`frames_per_beat` frames are computed for each beat) (only exists if reference beats are available)..
     * ``params``: A set of parameters of the actual type of features.
 
 Pre-computed features for the `SPAM dataset <https://github.com/urinieto/msaf-data/tree/master/SPAM>`_ can be found `here <https://ccrma.stanford.edu/%7Eurinieto/SPAM/SPAM-features.tgz>`_.

--- a/examples/run_msaf.py
+++ b/examples/run_msaf.py
@@ -64,6 +64,13 @@ if __name__ == "__main__":
         default=False,
     )
     parser.add_argument(
+        "-mb",
+        action="store_true",
+        dest="multibeat",
+        help="Compute mulitple frames per beat",
+        default=False,
+    )
+    parser.add_argument(
         "-j",
         action="store",
         dest="n_jobs",
@@ -113,6 +120,7 @@ if __name__ == "__main__":
         "annot_beats": args.annot_beats,
         "feature": args.feature,
         "framesync": args.framesync,
+        "multibeat": args.multibeat,
         "boundaries_id": args.boundaries_id,
         "labels_id": args.labels_id,
         "n_jobs": args.n_jobs,

--- a/msaf/algorithms/interface.py
+++ b/msaf/algorithms/interface.py
@@ -51,6 +51,7 @@ class SegmenterInterface:
         feature="pcp",
         annot_beats=False,
         framesync=False,
+        multibeat=False,
         features=None,
         **config
     ):
@@ -80,6 +81,7 @@ class SegmenterInterface:
         self.feature_str = feature
         self.annot_beats = annot_beats
         self.framesync = framesync
+        self.multibeat = multibeat
         self.config = config
         self.features = features
 

--- a/msaf/base.py
+++ b/msaf/base.py
@@ -184,7 +184,7 @@ class Features(metaclass=MetaFeatures):
                 )
         return times, frames
 
-    def compute_beat_sync_features(self, beat_frames, beat_times, pad):
+    def compute_beat_sync_features(self, beat_frames, beat_times, pad, frames_per_beat=1):
         """Make the features beat-synchronous.
 
         Parameters
@@ -207,6 +207,16 @@ class Features(metaclass=MetaFeatures):
         """
         if beat_frames is None:
             return None, None
+        if frames_per_beat != 1:
+            new_beat_frames = np.empty(0,dtype=int)
+            for idx in range(len(beat_frames)-1):
+                this_beat_frame = beat_frames[idx]
+                next_beat_frame = beat_frames[idx+1]
+                subdivision = (next_beat_frame - this_beat_frame)
+                assert (frames_per_beat < subdivision)
+                frames_in_beat = [int(k * subdivision/frames_per_beat + this_beat_frame) for k in range(frames_per_beat)]
+                new_beat_frames = np.concatenate((new_beat_frames, frames_in_beat), dtype=int )
+            beat_frames = new_beat_frames
 
         # Make beat synchronous
         beatsync_feats = librosa.util.utils.sync(

--- a/msaf/configdefaults.py
+++ b/msaf/configdefaults.py
@@ -33,6 +33,7 @@ AddConfigVar(
 AddConfigVar("sample_rate", "Default Sample Rate to be used.", IntParam(22050))
 AddConfigVar("n_fft", "FFT size", IntParam(4096))
 AddConfigVar("hop_size", "Hop length in samples", IntParam(1024))
+AddConfigVar("frames_per_beat","The number of framees computed per beat on multibeat", IntParam(3))
 
 
 # Files and dirs

--- a/msaf/eval.py
+++ b/msaf/eval.py
@@ -337,6 +337,7 @@ def process(
     labels_id=msaf.config.default_label_id,
     annot_beats=False,
     framesync=False,
+    multibeat=False,
     feature="pcp",
     hier=False,
     save=False,
@@ -389,7 +390,7 @@ def process(
     # Set up configuration based on algorithms parameters
     if config is None:
         config = io.get_configuration(
-            feature, annot_beats, framesync, boundaries_id, labels_id
+            feature, annot_beats, framesync, multibeat, boundaries_id, labels_id
         )
 
     # Hierarchical segmentation

--- a/msaf/exceptions.py
+++ b/msaf/exceptions.py
@@ -43,3 +43,6 @@ class NoEstimationsError(MSAFError):
 
 class WrongAlgorithmID(MSAFError):
     """This algorithm was not found in msaf."""
+
+class FramePerBeatTooHigh(MSAFError):
+    """Frames per beat is higher than the number of frames between two beats"""

--- a/msaf/features.py
+++ b/msaf/features.py
@@ -41,6 +41,7 @@ class CQT(Features):
         norm=config.cqt.norm,
         filter_scale=config.cqt.filter_scale,
         ref_power=config.cqt.ref_power,
+        frames_per_beat=config.frames_per_beat
     ):
         """Constructor of the class.
 
@@ -64,10 +65,12 @@ class CQT(Features):
         ref_power: str
             The reference power for logarithmic scaling.
             See `configdefaults.py` for the possible values.
+        frames_per_beat: int
+            The number of frames to compute when using multibeat
         """
         # Init the parent
         super().__init__(
-            file_struct=file_struct, sr=sr, hop_length=hop_length, feat_type=feat_type
+            file_struct=file_struct, sr=sr, hop_length=hop_length, feat_type=feat_type, frames_per_beat=frames_per_beat
         )
         # Init the CQT parameters
         self.n_bins = n_bins
@@ -134,6 +137,7 @@ class Mel(Features):
         n_mels=config.mel.n_mels,
         f_min=config.mel.f_min,
         f_max=config.mel.f_max,
+        frames_per_beat=config.frames_per_beat
     ):
         """Constructor of the class.
 
@@ -156,10 +160,12 @@ class Mel(Features):
             Minimum frequency.
         f_min: int > 0
             Maximal frequency.
+        frames_per_beat: int
+            The number of frames to compute when using multibeat
         """
         # Init the parent
         super().__init__(
-            file_struct=file_struct, sr=sr, hop_length=hop_length, feat_type=feat_type
+            file_struct=file_struct, sr=sr, hop_length=hop_length, feat_type=feat_type, frames_per_beat=frames_per_beat
         )
         self.n_fft = n_fft
         # Init the Mel parameters
@@ -213,6 +219,7 @@ class LogMel(Features):
         n_mels=config.mel.n_mels,
         f_min=config.mel.f_min,
         f_max=config.mel.f_max,
+        frames_per_beat=config.frames_per_beat
     ):
         """Constructor of the class.
 
@@ -235,10 +242,12 @@ class LogMel(Features):
             Minimum frequency.
         f_min: int > 0
             Maximal frequency.
+        frames_per_beat: int
+            The number of frames to compute when using multibeat
         """
         # Init the parent
         super().__init__(
-            file_struct=file_struct, sr=sr, hop_length=hop_length, feat_type=feat_type
+            file_struct=file_struct, sr=sr, hop_length=hop_length, feat_type=feat_type, frames_per_beat=frames_per_beat
         )
         self.n_fft = n_fft
         # Init the Mel parameters
@@ -290,6 +299,7 @@ class MFCC(Features):
         n_mels=config.mfcc.n_mels,
         n_mfcc=config.mfcc.n_mfcc,
         ref_power=config.mfcc.ref_power,
+        frames_per_beat=config.frames_per_beat
     ):
         """Constructor of the class.
 
@@ -312,10 +322,12 @@ class MFCC(Features):
             Number of mel coefficients.
         ref_power: function
             The reference power for logarithmic scaling.
+        frames_per_beat: int
+            The number of frames to compute when using multibeat
         """
         # Init the parent
         super().__init__(
-            file_struct=file_struct, sr=sr, hop_length=hop_length, feat_type=feat_type
+            file_struct=file_struct, sr=sr, hop_length=hop_length, feat_type=feat_type, frames_per_beat=frames_per_beat
         )
         # Init the MFCC parameters
         self.n_fft = n_fft
@@ -372,6 +384,7 @@ class PCP(Features):
         norm=config.pcp.norm,
         f_min=config.pcp.f_min,
         n_octaves=config.pcp.n_octaves,
+        frames_per_beat=config.frames_per_beat
     ):
         """Constructor of the class.
 
@@ -394,10 +407,12 @@ class PCP(Features):
             Minimum frequency.
         n_octaves: int > 0
             Number of octaves.
+        frames_per_beat: int
+            The number of frames to compute when using multibeat
         """
         # Init the parent
         super().__init__(
-            file_struct=file_struct, sr=sr, hop_length=hop_length, feat_type=feat_type
+            file_struct=file_struct, sr=sr, hop_length=hop_length, feat_type=feat_type, frames_per_beat=frames_per_beat
         )
         # Init the PCP parameters
         self.n_bins = n_bins
@@ -460,6 +475,7 @@ class Tonnetz(Features):
         norm=config.tonnetz.norm,
         f_min=config.tonnetz.f_min,
         n_octaves=config.tonnetz.n_octaves,
+        frames_per_beat=config.frames_per_beat
     ):
         """Constructor of the class.
 
@@ -482,10 +498,12 @@ class Tonnetz(Features):
             Minimum frequency.
         n_octaves: int > 0
             Number of octaves.
+        frames_per_beat: int
+            The number of frames to compute when using multibeat
         """
         # Init the parent
         super().__init__(
-            file_struct=file_struct, sr=sr, hop_length=hop_length, feat_type=feat_type
+            file_struct=file_struct, sr=sr, hop_length=hop_length, feat_type=feat_type, frames_per_beat=frames_per_beat
         )
         # Init the local parameters
         self.n_bins = n_bins
@@ -534,6 +552,7 @@ class Tempogram(Features):
         sr=config.sample_rate,
         hop_length=config.hop_size,
         win_length=config.tempogram.win_length,
+        frames_per_beat=config.frames_per_beat
     ):
         """Constructor of the class.
 
@@ -550,10 +569,12 @@ class Tempogram(Features):
             Hop size in frames for the analysis.
         win_length: int > 0
             The size of the window for the tempogram.
+        frames_per_beat: int
+            The number of frames to compute when using multibeat
         """
         # Init the parent
         super().__init__(
-            file_struct=file_struct, sr=sr, hop_length=hop_length, feat_type=feat_type
+            file_struct=file_struct, sr=sr, hop_length=hop_length, feat_type=feat_type, frames_per_beat=frames_per_beat
         )
         # Init the local parameters
         self.win_length = win_length

--- a/msaf/input_output.py
+++ b/msaf/input_output.py
@@ -356,13 +356,14 @@ def get_all_label_algorithms():
     return algo_ids
 
 
-def get_configuration(feature, annot_beats, framesync, boundaries_id, labels_id):
+def get_configuration(feature, annot_beats, framesync, multibeat, boundaries_id, labels_id):
     """Gets the configuration dictionary from the current parameters of the
     algorithms to be evaluated."""
     config = {}
     config["annot_beats"] = annot_beats
     config["feature"] = feature
     config["framesync"] = framesync
+    config["multibeat"] = multibeat
     bound_config = {}
     if boundaries_id != "gt":
         bound_config = eval(msaf.algorithms.__name__ + "." + boundaries_id).config

--- a/msaf/run.py
+++ b/msaf/run.py
@@ -254,7 +254,7 @@ def process_track(file_struct, boundaries_id, labels_id, config, annotator_id=0)
 
     # Get features
     config["features"] = Features.select_features(
-        config["feature"], file_struct, config["annot_beats"], config["framesync"]
+        config["feature"], file_struct, config["annot_beats"], config["framesync"], multibeat=config["multibeat"]
     )
 
     # Get estimations
@@ -286,6 +286,7 @@ def process(
     config=None,
     out_bounds="out_bounds.wav",
     out_sr=22050,
+    multibeat=False
 ):
     """Main process to segment a file or a collection of files.
 
@@ -324,6 +325,8 @@ def process(
         mode, when sonify_bounds is True.
     out_sr : int
         Sampling rate for the sonified bounds.
+    multibeat : bool
+        Whether to use multibeat.
 
     Returns
     -------
@@ -338,7 +341,7 @@ def process(
     # Set up configuration based on algorithms parameters
     if config is None:
         config = io.get_configuration(
-            feature, annot_beats, framesync, boundaries_id, labels_id
+            feature, annot_beats, framesync, multibeat, boundaries_id, labels_id
         )
         config["features"] = None
 
@@ -356,7 +359,7 @@ def process(
 
         # Get features
         config["features"] = Features.select_features(
-            feature, file_struct, annot_beats, framesync
+            feature, file_struct, annot_beats, framesync, multibeat=multibeat
         )
 
         # And run the algorithms

--- a/tests/features/chirp_noaudio.json
+++ b/tests/features/chirp_noaudio.json
@@ -11,12 +11,14 @@
     "audio_file": "fixtures/chirp_noaudio.mp3",
     "dur": 10.0,
     "sample_rate": 22050,
-    "hop_length": 1024
+    "hop_length": 1024,
+    "frames_per_beat": 3
   },
   "est_beats": [],
   "est_beatsync_times": [],
   "cqt": {
     "est_beatsync": [],
+    "est_multibeat": [],
     "params": {
       "filter_scale": "1.0",
       "ref_power": "amax",

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -48,6 +48,8 @@ def run_framesync(features_class):
     assert "framesync" in data[features_class.get_id()].keys()
     assert "est_beatsync" in data[features_class.get_id()].keys()
     assert "ann_beatsync" in data[features_class.get_id()].keys()
+    assert "est_multibeat" in data[features_class.get_id()].keys()
+    assert "ann_multibeat" in data[features_class.get_id()].keys()
     read_feats = np.array(data[features_class.get_id()]["framesync"])
     assert np.array_equal(feats, read_feats)
 
@@ -311,6 +313,14 @@ def test_select_features():
     feature = Features.select_features("cqt", my_file_struct, True, False)
     assert isinstance(feature, CQT)
     assert feature.feat_type == FeatureTypes.ann_beatsync
+
+    feature = Features.select_features("mfcc", my_file_struct, False, False, multibeat=True)
+    assert isinstance(feature, MFCC)
+    assert feature.feat_type == FeatureTypes.est_multibeat
+
+    feature = Features.select_features("cqt", my_file_struct, True, False, multibeat=True)
+    assert isinstance(feature, CQT)
+    assert feature.feat_type == FeatureTypes.ann_multibeat
 
 
 def test_wrong_select_features():

--- a/tests/test_multibeat.py
+++ b/tests/test_multibeat.py
@@ -1,0 +1,59 @@
+import json
+import os
+import pytest
+from pytest import fixture
+from enum import Enum
+
+import librosa
+import numpy as np
+from pytest import raises
+
+import msaf
+from msaf.base import FeatureTypes
+from msaf.exceptions import FramePerBeatTooHigh
+from msaf.features import Features, CQT
+from msaf.input_output import FileStruct
+
+# Move to __file__ path
+os.chdir(os.path.dirname(__file__))
+
+# Global vars
+audio_file = os.path.join("fixtures", "chirp.mp3")
+file_struct = FileStruct(audio_file)
+file_struct.ref_file = os.path.join("fixtures", "chirp.jams")
+msaf.utils.ensure_dir("features")
+features_file = os.path.join("features", "chirp.json")
+file_struct.features_file = features_file
+try:
+    os.remove(features_file)
+except OSError:
+    pass
+
+multibeat_feature = np.array([[k*2, k*2+1] for k in range(10)])
+print(multibeat_feature)
+
+@fixture
+def feat_class():
+    return CQT(file_struct, FeatureTypes.est_multibeat)
+
+def test_compute_multibeat(feat_class):
+    assert (feat_class._compute_multibeat(None) is None)
+    assert (feat_class._compute_multibeat([]) == [])
+    frame_beats = [k*100 for k in range (10)]
+    assert (isinstance(feat_class._compute_multibeat(frame_beats), np.ndarray))
+    assert (feat_class._compute_multibeat(frame_beats).shape[0] == feat_class.frames_per_beat * (len(frame_beats) - 1))
+    feat_class.frames_per_beat = 100
+    with raises(FramePerBeatTooHigh):
+        feat_class._compute_multibeat(frame_beats)
+
+def test_shape_beatwise(feat_class):
+    assert (feat_class._shape_beatwise(None) is None)
+    assert (feat_class._shape_beatwise(np.array([])).shape[0] == 0)
+    multibeat_feature = np.array([[k*2, k*2+1] for k in range(50)])
+    multibeat_shaped = feat_class._shape_beatwise(multibeat_feature)
+    assert(isinstance(multibeat_shaped, np.ndarray))
+    assert(multibeat_shaped.shape[0] == len(multibeat_feature)//feat_class.frames_per_beat)
+    assert(multibeat_shaped.shape[1] == 2 * feat_class.frames_per_beat)
+    assert(np.equal(multibeat_shaped[0],np.array([0,1,2,3,4,5])).all())
+
+

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -76,6 +76,7 @@ def test_run_algorithms():
     feature = "pcp"
     annot_beats = False
     framesync = False
+    multibeat = False
     file_struct = msaf.io.FileStruct(audio_file)
     file_struct.features_file = msaf.config.features_tmp_file
 
@@ -84,7 +85,7 @@ def test_run_algorithms():
         for label_id in label_ids:
             print(f"bound_id: {bound_id},\tlabel_id: {label_id}")
             config = msaf.io.get_configuration(
-                feature, annot_beats, framesync, bound_id, label_id
+                feature, annot_beats, framesync, multibeat, bound_id, label_id
             )
             config["hier"] = False
             config["features"] = Features.select_features(
@@ -105,7 +106,7 @@ def test_run_algorithms():
     def _test_run_msaf(bound_id, label_id, hier=False):
         print(f"bound_id: {bound_id},\tlabel_id: {label_id}")
         config = msaf.io.get_configuration(
-            feature, annot_beats, framesync, bound_id, label_id
+            feature, annot_beats, framesync, multibeat, bound_id, label_id
         )
         config["hier"] = hier
         config["features"] = Features.select_features(
@@ -175,6 +176,7 @@ def test_process_track():
     config["annot_beats"] = False
     config["framesync"] = False
     config["hier"] = False
+    config["multibeat"] = False
     est_times, est_labels = msaf.run.process_track(
         file_struct, bounds_id, labels_id, config
     )


### PR DESCRIPTION
This PR add a new feature  representation with a fixed number of frames per beats. This is an advancement of issue #154 , but on beats instead of bars.

For the user this adds :

- A configurable parameter `frames_per_beat` (int, default 3). The number of frames sampled for each beat.
- An argument of `Feature` : `multibeat` (bool, default False). Whether to use this representation or not.
- An in line parameter of the `run_MSAF.py` :  `-mb`. To use this representation.
- A little bit of documentaion.

In the `Feature` class :

-  `self._est_multibeat_features` and `self._ann_mutlibeat_features` where the representation will be for resp. estimated beats and annotated beats.
- ` self._est_multibeat_frames` and `self._ann_multibeat_frames` with the frame index of the beats. (We remove the last beat from `self._est_beatsync_frames`, because we compute frames _between_ beats)
- `self._est_multibeat_times` and `self._ann_multibeat_times` with the times in secondes of the beats. 
- `_compute_multibeat(self, beat_frames)` to compute the index of the frames used for the representation
- `_shape_beatwise(self, multibeat_features)` to stack the feature representation as a beatwise TF matrix.
- It also does some refactoring of `compute_beat_sync_features` in order to use the same function to compute multibeat features. The padding of `beat_times` is moved to a new function called `_pad_beats_times`
- Two new `FeatureTypes` : `est_multibeat` and `ann_multibeat` and the appropriate code in `select_features(...)`
- A new Exception `FramesPerBeatTooHigh` raised by '_compute_multibeat()` if the number of frames between two beats is lower than `frames_per_beat`.
- Tests of the functions in `test_multibeat.py`

Thanks for reading, and reviewing code 😃 
