### PR TITLE
Fix installations for Python 3.12

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,6 +16,8 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
+          - "3.12"
     steps:
       - uses: actions/checkout@v3
         with:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,6 +12,7 @@
 
 import os
 import sys
+import importlib.util
 
 import sphinx
 
@@ -148,9 +149,12 @@ copyright = "2015-2018, msaf development team"
 # built documents.
 #
 
-import imp
+spec = importlib.util.spec_from_file_location(
+    "msaf.version", os.path.abspath("../msaf/version.py")
+)
+msaf = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(msaf)
 
-msaf = imp.load_source("msaf.version", "../msaf/version.py")
 # The short X.Y version.
 version = msaf.short_version
 # The full version, including alpha/beta/rc tags.

--- a/msaf/algorithms/foote/segmenter.py
+++ b/msaf/algorithms/foote/segmenter.py
@@ -15,7 +15,7 @@ def median_filter(X, M=8):
 
 def compute_gaussian_krnl(M):
     """Creates a gaussian kernel following Foote's paper."""
-    g = signal.gaussian(M, M // 3.0, sym=True)
+    g = signal.windows.gaussian(M, M // 3.0, sym=True)
     G = np.dot(g.reshape(-1, 1), g.reshape(1, -1))
     G[M // 2 :, : M // 2] = -G[M // 2 :, : M // 2]
     G[: M // 2, M // 2 :] = -G[: M // 2, M // 2 :]

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,11 @@
 import glob
-import imp
+import importlib.util
 
-from setuptools import find_packages, setup
+from setuptools import setup, find_packages
 
-version = imp.load_source("msaf.version", "msaf/version.py")
+spec = importlib.util.spec_from_file_location("msaf.version", "msaf/version.py")
+version = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(version)
 
 # MSAF configuration
 setup(

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ setup(
         "cvxopt",
         "decorator",
         "enum34",
-        "future",
         "jams >= 0.3.0",
         "joblib",
         "librosa >= 0.6.0",


### PR DESCRIPTION
Need to replace imp with importlib in setup.py for Python 3.12 support (imp has been removed now).